### PR TITLE
feat(s3): minimal BPMN process — happy path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ ZEEBE_GRPC=localhost:26500
 ZEEBE_REST=http://localhost:8088
 CAMUNDA_OPERATE_URL=http://localhost:8088
 
+# CI cluster (for automated tests, no auth required):
+# ZEEBE_GRPC=localhost:36500
+# ZEEBE_REST=http://localhost:18088
+# CAMUNDA_OPERATE_URL=http://localhost:18088
+
 # LLM reviewer APIs (Session 13 -- mock reviewers until then)
 # OPENAI_API_KEY=sk-...
 # GOOGLE_API_KEY=...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-all lint typecheck check fmt
+.PHONY: test test-all lint typecheck check fmt test-integration
 
 test:
 	uv run pytest -x -q
@@ -13,6 +13,9 @@ typecheck:
 	uv run mypy src/
 
 check: lint typecheck test
+
+test-integration:
+	uv run pytest -m integration -v
 
 fmt:
 	uv run ruff format src/ tests/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ typecheck:
 check: lint typecheck test
 
 test-integration:
-	uv run pytest -m integration -v
+	uv run pytest -m integration -v --override-ini="addopts="
 
 fmt:
 	uv run ruff format src/ tests/

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Camunda orchestrates across contexts. Domain services own semantic truth. DMN ta
 ```bash
 git clone https://github.com/Troubladore/sdlc-control-plane.git
 cd sdlc-control-plane
-uv sync --extra dev
+uv sync --extra dev                # Core development
+uv sync --extra dev --extra camunda  # With Camunda/Zeebe support
 ```
 
 ### Run Tests
@@ -69,6 +70,7 @@ uv sync --extra dev
 ```bash
 make check    # lint + type check + tests
 make test     # just tests
+make test-integration  # Integration tests (requires live Camunda cluster)
 ```
 
 ### CLI
@@ -113,6 +115,7 @@ docs/
 |--------|------------|-------------|
 | Architecture | [Design Doc](docs/design/2026-03-10-issue-114-sdlc-control-plane-design.md) | System design and session roadmap |
 | Verification | [docs/verification/](docs/verification/README.md) | Evidence model, referential validation, diagnostics |
+| Orchestration | [docs/orchestration/](docs/orchestration/README.md) | Zeebe client facade, BPMN process model |
 | Decisions | [docs/decisions/](docs/decisions/README.md) | Why specific technical choices were made |
 | Process | [docs/process/](docs/process/) | Certificate-driven development workflow |
 | Implementation | [CLAUDE.md](CLAUDE.md) | Contributing and development conventions |

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -5,6 +5,14 @@
 
 Design decisions record *why* specific technical choices were made. Each decision evaluates options with trade-offs and documents the chosen approach.
 
+## Session 3: Minimal BPMN Process (Happy Path)
+
+| Decision | Summary |
+|----------|---------|
+| [Handler `**kwargs` Pattern](s3-handler-kwargs-pattern.md) | Use `**kwargs` in pyzeebe handlers; `job: Job` annotation broken under PEP 563 |
+| [Sync/Async Strategy](s3-sync-async-strategy.md) | `SyncZeebeClient` for deploy/start; `asyncio.run()` wrapping `ZeebeWorker` for job completion |
+| [CI Cluster Topology](s3-ci-cluster-topology.md) | Integration tests target unauthenticated CI cluster (36500/18088); auth deferred |
+
 ## Session 2: Evidence Inventory + Referential Validation
 
 | Decision | Summary |

--- a/docs/decisions/s3-ci-cluster-topology.md
+++ b/docs/decisions/s3-ci-cluster-topology.md
@@ -1,0 +1,66 @@
+# Decision: Integration Tests Target CI Cluster
+
+> **Session:** S3 — Minimal BPMN Process (Happy Path)
+> **Date:** 2026-03-12
+> **Status:** Decided
+> **Audience:** Contributors, CI pipeline operators
+> **Reading order:** [docs/decisions/README.md](README.md) → this document
+
+**Decision:** S3 integration tests target the CI cluster (ports 36500/18088), not the main cluster. Auth support is deferred.
+
+## Context and Requirements
+
+The local Camunda 8.8 stack (at `~/repos/camunda/`) runs two clusters:
+
+| Cluster | Zeebe gRPC | REST | Auth |
+|---------|-----------|------|------|
+| Main | 26500 | 8088 | Required (returns 401 on unauthenticated REST calls) |
+| CI | 36500 | 18088 | None (`unprotectedApi: true`) |
+
+S3 integration tests need to deploy BPMN, start instances, and query process state via the REST API. Implementing OAuth2/Basic auth for the main cluster is out of scope for S3.
+
+## Options Evaluated
+
+### Option A: Target main cluster, implement auth
+
+Add authentication support (Bearer token or Basic auth) to the Camunda REST client before running integration tests.
+
+**Trade-offs:**
+- Pro: Tests run against the same cluster used interactively.
+- Con: Auth implementation is non-trivial scope that belongs in a later session.
+- Con: Credentials in test fixtures create a secret-management concern.
+- Con: Blocks S3 tests on auth infrastructure rather than on BPMN correctness.
+
+### Option B: Target CI cluster (chosen)
+
+Integration tests default to the CI cluster (`ZEEBE_GRPC=localhost:36500`, `ZEEBE_REST=http://localhost:18088`). No auth headers required. Test fixtures set these defaults; they are overridable via environment variables.
+
+**Trade-offs:**
+- Pro: Tests run immediately without auth credentials.
+- Pro: CI cluster is purpose-built for automated testing — isolated from interactive work on the main cluster.
+- Pro: Ports are overridable, so tests can target any cluster when auth is added later.
+- Con: Tests do not exercise the auth code path (deferred to a future session).
+- Con: Developer must remember to start both clusters when running integration tests.
+
+### Option C: Mock the Camunda client entirely
+
+Replace the Zeebe client with a mock in integration tests; no live cluster required.
+
+**Trade-offs:**
+- Pro: No external dependency.
+- Con: Defeats the purpose of integration tests — BPMN deployment and execution fidelity are exactly what S3 must verify.
+
+## Chosen Approach: Option B
+
+S3 integration tests target the CI cluster. The `.env.example` defaults remain pointed at the main cluster (26500/8088) for interactive use. Test fixtures default to CI cluster ports and read `ZEEBE_GRPC_TEST` / `ZEEBE_REST_TEST` env vars so the target is overridable in any environment.
+
+### Implementation Note: `processInstanceKey` Must Be a String
+
+When querying `/v2/process-instances/search` via the Camunda REST API, the `processInstanceKey` filter value must be passed as a **string**, not an integer. Passing an integer returns HTTP 400. pyzeebe returns the key as a Python `int`; callers must convert with `str(key)` before including it in the filter payload.
+
+## Related
+
+- Code: `tests/integration/test_s3_happy_path.py` — CI cluster fixtures, `str(key)` conversion
+- Code: `src/sdlc_control_plane/orchestration/client.py` — REST query helpers
+- Config: `.env.example` — main cluster defaults for interactive use
+- Infrastructure: `~/repos/camunda/` — Docker Compose stack with both clusters

--- a/docs/decisions/s3-handler-kwargs-pattern.md
+++ b/docs/decisions/s3-handler-kwargs-pattern.md
@@ -1,0 +1,73 @@
+# Decision: pyzeebe Handler `**kwargs` Pattern
+
+> **Session:** S3 — Minimal BPMN Process (Happy Path)
+> **Date:** 2026-03-12
+> **Status:** Decided
+> **Audience:** Contributors, Camunda integration implementors
+> **Reading order:** [docs/decisions/README.md](README.md) → this document
+
+**Decision:** pyzeebe task handlers use `**kwargs: Any` instead of `job: Job` parameter annotation.
+
+## Context and Requirements
+
+S3 adds a `ZeebeClient` wrapper that registers job workers via pyzeebe 4.x. pyzeebe's decorator (`@worker.task`) inspects handler parameters at registration time to determine which job variables to inject into the handler call. This introspection uses `inspect.signature()` and checks parameter annotations.
+
+The project uses `from __future__ import annotations` (PEP 563) in all modules for forward-reference support. PEP 563 turns all type hints into strings at runtime — annotations are not evaluated until explicitly requested.
+
+## Options Evaluated
+
+### Option A: `job: Job` annotation (rejected)
+
+```python
+from pyzeebe.job.job import Job
+
+async def handler(job: Job) -> dict:
+    job_type = job.type
+    ...
+```
+
+pyzeebe's `parameter_tools.get_parameters_from_function` checks `param.annotation == Job` (identity comparison against the class object). With PEP 563, `param.annotation` is the string `"Job"` (or the internal `"_Job"`), not the class. The identity check fails silently and the handler is called with zero positional arguments, raising `TypeError` at runtime.
+
+**Trade-offs:**
+- Pro: Explicit type annotation on the handler.
+- Con: Silently broken under PEP 563 — no warning at registration, crash on first job.
+- Con: Requires removing `from __future__ import annotations` from `client.py` while the rest of the project keeps it.
+
+### Option B: `**kwargs: Any` (chosen)
+
+```python
+async def handler(**kwargs: Any) -> dict:
+    job_type = job_type_name  # captured from outer closure
+    ...
+```
+
+pyzeebe treats `**kwargs` as "accept all job variables as keyword arguments." No annotation introspection is required. The job type is captured from the enclosing `register_handler` closure variable rather than read from a `Job` object.
+
+**Trade-offs:**
+- Pro: Correct under PEP 563 — no annotation introspection at all.
+- Pro: Consistent with the project-wide `from __future__ import annotations` convention.
+- Pro: Handler receives all job variables as a plain dict — straightforward to forward.
+- Con: Loses static type safety on individual handler parameters.
+- Con: Job metadata fields (beyond `type`) require an alternate access path if needed in future.
+
+### Option C: Remove `from __future__ import annotations` from `client.py`
+
+Keep `job: Job` annotation but remove the future import from the one file where it causes a problem.
+
+**Trade-offs:**
+- Pro: Preserves annotation type safety.
+- Con: Inconsistent with the project convention — every other module uses PEP 563.
+- Con: Forward references in `client.py` would then require string quoting manually.
+- Con: Hides the root incompatibility rather than addressing it.
+
+## Chosen Approach: Option B
+
+Use `**kwargs: Any` in all pyzeebe task handlers. Job type is captured from the closure variable in `register_handler`, not from `job.type`. This is the only approach that is correct under PEP 563 without creating per-file import inconsistency.
+
+This is a pyzeebe 4.x + PEP 563 incompatibility. If pyzeebe adds `get_type_hints()`-based introspection in a future release, this decision can be revisited.
+
+## Related
+
+- Code: `src/sdlc_control_plane/orchestration/client.py` — `register_handler()`, handler closure
+- Upstream: pyzeebe `pyzeebe/utils/parameter_tools.py` — `get_parameters_from_function()`
+- PEP 563: https://peps.python.org/pep-0563/

--- a/docs/decisions/s3-sync-async-strategy.md
+++ b/docs/decisions/s3-sync-async-strategy.md
@@ -1,0 +1,65 @@
+# Decision: Sync/Async Strategy for Zeebe Client
+
+> **Session:** S3 — Minimal BPMN Process (Happy Path)
+> **Date:** 2026-03-12
+> **Status:** Decided
+> **Audience:** Contributors, Camunda integration implementors
+> **Reading order:** [docs/decisions/README.md](README.md) → this document
+
+**Decision:** Use `SyncZeebeClient` for deploy/start operations and `asyncio.run()` wrapping `ZeebeWorker` for job completion.
+
+## Context and Requirements
+
+pyzeebe 4.x provides three execution surfaces:
+
+| Class | Interface | Use case |
+|-------|-----------|----------|
+| `ZeebeClient` | `async` | Request-response gRPC (deploy, create instance) |
+| `SyncZeebeClient` | Sync wrapper over `ZeebeClient` | Same, callable from sync code |
+| `ZeebeWorker` | `async` only | Long-running job subscription loop |
+
+The CLI is synchronous (Click). The S3 scope requires: deploy a BPMN, start a process instance, complete a job, and confirm the instance reached an end state. The question is which execution model to use for each operation.
+
+## Options Evaluated
+
+### Option A: All async with `pytest-asyncio`
+
+Use `ZeebeClient` everywhere, mark all tests `@pytest.mark.asyncio`, add `pytest-asyncio` as a dev dependency.
+
+**Trade-offs:**
+- Pro: Uniform async model throughout.
+- Con: Adds a test dependency that complicates the test surface for non-Camunda tests.
+- Con: The Click CLI must still wrap everything in `asyncio.run()` at the entry point.
+- Con: Overly broad — most operations are simple request-response calls that don't benefit from async.
+
+### Option B: All sync via `SyncZeebeClient`
+
+Use `SyncZeebeClient` for all operations. Avoid async entirely.
+
+**Trade-offs:**
+- Pro: Simple, no event loop management.
+- Con: `ZeebeWorker` has no sync equivalent in pyzeebe 4.x — this option cannot support job workers at all.
+- Con: Defers the async question without resolving it, blocking any worker-based workflows.
+
+### Option C: Hybrid — `SyncZeebeClient` for request-response, `asyncio.run()` for worker (chosen)
+
+`deploy_process()` and `create_instance()` use `SyncZeebeClient`. `run_worker()` constructs a fresh `ZeebeWorker` with its own gRPC channel and wraps it in `asyncio.run()`.
+
+**Trade-offs:**
+- Pro: `SyncZeebeClient` is natural for the CLI's synchronous call sites.
+- Pro: `asyncio.run()` is the correct boundary for `ZeebeWorker` — it starts a fresh event loop, runs to completion, and exits cleanly.
+- Pro: No new test dependencies; async integration tests use `asyncio.run()` directly or a thin sync wrapper.
+- Con: The `run_worker()` path creates a separate gRPC channel — it cannot share the channel used by `SyncZeebeClient` across event loop boundaries.
+- Con: Slightly more explicit channel lifecycle management required.
+
+## Chosen Approach: Option C
+
+`deploy_process()` and `create_instance()` are simple request-response operations — `SyncZeebeClient` handles them naturally from a sync CLI context. `run_worker()` requires `ZeebeWorker`, which is async-only; it runs under `asyncio.run()` with a fresh channel, isolated from the sync client's channel. Channel isolation across event loop boundaries is a pyzeebe/gRPC requirement, not a workaround.
+
+If the project later adopts a fully async CLI entry point (e.g., `asyncio.run(main())`), the hybrid can be collapsed into uniform `ZeebeClient` usage. That refactor is deferred until there is a demonstrated need.
+
+## Related
+
+- Code: `src/sdlc_control_plane/orchestration/client.py` — `ZeebeClient` wrapper, `run_worker()`
+- pyzeebe docs: `SyncZeebeClient`, `ZeebeWorker`
+- Session scope: S3 happy-path integration test in `tests/integration/test_s3_happy_path.py`

--- a/docs/orchestration/README.md
+++ b/docs/orchestration/README.md
@@ -1,0 +1,95 @@
+# Delivery Orchestration
+
+> **Status:** Normative — authoritative for current behavior
+> **Audience:** Contributors working on Camunda/Zeebe integration
+> **Reading order:** Start with project README.md, then this document
+
+The Delivery Orchestration bounded context owns the thin facade over pyzeebe for Camunda 8 interaction: BPMN process deployment, workflow instance creation, and connection configuration.
+
+## Components
+
+| Component | Code | Responsibility |
+|-----------|------|----------------|
+| Configuration | `src/sdlc_control_plane/orchestration/config.py` | `ZeebeConfig` — reads env vars, validates connection parameters |
+| Client | `src/sdlc_control_plane/orchestration/client.py` | `ZeebeClient` — deploy processes, create instances, result types |
+
+### ZeebeConfig
+
+`ZeebeConfig` is a Pydantic settings model that reads from environment variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ZEEBE_GRPC` | `localhost:26500` | Zeebe gRPC gateway address |
+| `ZEEBE_REST` | `http://localhost:8088` | Zeebe REST API base URL |
+| `CAMUNDA_OPERATE_URL` | `http://localhost:8088` | Camunda Operate UI/API URL |
+
+### ZeebeClient
+
+`ZeebeClient` wraps `pyzeebe` and exposes two operations:
+
+- `deploy_process(bpmn_path)` → `DeploymentResult` — deploys a BPMN file to the connected Zeebe instance
+- `create_instance(process_id, variables)` → `InstanceResult` — starts a workflow instance by process ID
+
+**Result types:**
+
+- `DeploymentResult` — holds `process_definition_key`, `bpmn_process_id`, `version`, and `resource_name`
+- `InstanceResult` — holds `process_instance_key`, `bpmn_process_id`, `version`, and `process_definition_key`
+
+Both are Pydantic models; all fields are set from the Zeebe API response.
+
+## BPMN Process
+
+`processes/issue-lifecycle.bpmn` is the happy-path issue lifecycle process. It contains 6 sequential service tasks:
+
+1. `validate-certificate` — validate the submitted certificate artifact
+2. `assign-reviewers` — select and assign two independent reviewers
+3. `run-review` — execute parallel review (competitive multi-model)
+4. `cross-validate` — reviewers cross-validate each other's certificates
+5. `resolve-disputes` — arbiter resolves any filed disputes
+6. `emit-workflow-event` — emit a `WorkflowEvent` to the measurement context
+
+The process is deployed via `ZeebeClient.deploy_process("processes/issue-lifecycle.bpmn")`.
+
+## Connection
+
+Copy `.env.example` to `.env` and set the three variables:
+
+```bash
+ZEEBE_GRPC=localhost:26500
+ZEEBE_REST=http://localhost:8088
+CAMUNDA_OPERATE_URL=http://localhost:8088
+```
+
+The local Camunda 8 full-stack cluster runs from `~/repos/camunda/` (Docker Compose). A separate CI cluster is available at `localhost:36500` (gRPC) and `localhost:18088` (REST).
+
+`pyzeebe` is an optional dependency. The client import is always conditional so the rest of the package loads without it:
+
+```python
+try:
+    from pyzeebe import ZeebeClient as _ZeebeClient
+except ImportError:
+    _ZeebeClient = None  # type: ignore[assignment,misc]
+```
+
+## Testing
+
+Unit tests mock the pyzeebe layer entirely — no live cluster required:
+
+```bash
+make test        # includes orchestration unit tests
+make check       # lint + type check + unit tests
+```
+
+Integration tests require a live Zeebe instance:
+
+```bash
+make test-integration  # Integration tests (requires live Camunda cluster)
+```
+
+Integration tests deploy `processes/issue-lifecycle.bpmn` and verify that `create_instance` returns a valid `InstanceResult`.
+
+## Current Limitations
+
+- **No auth support** — `ZeebeConfig` does not model OAuth credentials or TLS certificates; the client connects to an unsecured gRPC endpoint only.
+- **No secure channels** — TLS for the gRPC channel is not wired in; production use against a secured cluster requires manual `pyzeebe` configuration.
+- **Workers create separate channels** — if job workers are added in a future session, each worker opens its own channel rather than sharing the client channel.

--- a/docs/superpowers/plans/2026-03-12-s3-minimal-bpmn-process.md
+++ b/docs/superpowers/plans/2026-03-12-s3-minimal-bpmn-process.md
@@ -1,0 +1,1214 @@
+# S3: Minimal BPMN Process (Happy Path) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy a minimal 6-phase BPMN process to Camunda and prove the happy path completes via Operate.
+
+**Architecture:** Hand-authored BPMN XML with 6 sequential service tasks (Triage -> Design -> Planning -> Implement -> Review -> Integrate). Thin pyzeebe-based facade in `orchestration/` with lazy conditional imports. `SyncZeebeClient` for deploy/start operations; `asyncio.run()` wrapping `ZeebeWorker` for job completion only.
+
+**Tech Stack:** Python 3.10+, pyzeebe 4.x, Pydantic, BPMN 2.0 XML, httpx (dev), Camunda 8.8 CI cluster
+
+**Spec:** `docs/superpowers/specs/2026-03-11-s3-minimal-bpmn-process-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `processes/issue-lifecycle.bpmn` | BPMN 2.0 process model — 6 sequential service tasks |
+| Create | `src/sdlc_control_plane/orchestration/config.py` | `ZeebeConfig` Pydantic model, `from_env()` classmethod |
+| Create | `src/sdlc_control_plane/orchestration/client.py` | `ZeebeClient` facade — deploy, start, run_worker |
+| Modify | `src/sdlc_control_plane/orchestration/__init__.py` | Re-export `ZeebeConfig`, `ZeebeClient` |
+| Create | `tests/test_orchestration_config.py` | Unit tests for ZeebeConfig |
+| Create | `tests/test_orchestration_client.py` | Unit tests for ZeebeClient (mocked pyzeebe) |
+| Create | `tests/test_bpmn.py` | Unit tests for BPMN artifact correctness |
+| Create | `tests/test_workflow_integration.py` | Integration test — full happy path against CI cluster |
+| Modify | `tests/conftest.py` | Integration fixtures (zeebe_available, cleanup) |
+| Modify | `pyproject.toml` | Add `httpx` dev dep, register `integration` marker |
+| Modify | `Makefile` | Add `test-integration` target |
+| Modify | `.env.example` | Add CI cluster comment |
+
+---
+
+## Chunk 1: Project Configuration and BPMN Artifact
+
+### Task 1: Project Configuration Updates
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `Makefile`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add `httpx` to dev dependencies and register integration marker**
+
+In `pyproject.toml`, add `httpx` to `[project.optional-dependencies].dev` and
+add the `integration` marker to pytest config:
+
+```toml
+# In [project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "hypothesis>=6.90",
+    "mypy>=1.8",
+    "ruff>=0.3",
+    "httpx>=0.27",
+]
+
+# In [tool.pytest.ini_options] — add markers and default deselection:
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+markers = ["integration: requires live Camunda cluster"]
+addopts = "-m 'not integration'"
+```
+
+The `addopts = "-m 'not integration'"` line ensures `make test` (and bare
+`pytest`) never collects integration tests. Integration tests run only via
+the explicit `make test-integration` target which passes `-m integration`.
+
+- [ ] **Step 2: Add `test-integration` Makefile target**
+
+Add to `Makefile` after the existing `check` target:
+
+Also update the `.PHONY` line at the top of the Makefile to include `test-integration`:
+
+```makefile
+.PHONY: test test-all lint typecheck check fmt test-integration
+```
+
+Then add the target after the existing `check` target:
+
+```makefile
+test-integration:
+	uv run pytest -m integration -v
+```
+
+- [ ] **Step 3: Add CI cluster comment to `.env.example`**
+
+Add a comment block to `.env.example`:
+
+```bash
+# Camunda 8 connection (decoupled -- bring your own cluster)
+ZEEBE_GRPC=localhost:26500
+ZEEBE_REST=http://localhost:8088
+CAMUNDA_OPERATE_URL=http://localhost:8088
+
+# CI cluster (for automated tests, no auth required):
+# ZEEBE_GRPC=localhost:36500
+# ZEEBE_REST=http://localhost:18088
+# CAMUNDA_OPERATE_URL=http://localhost:18088
+
+# LLM reviewer APIs (Session 13 -- mock reviewers until then)
+# OPENAI_API_KEY=sk-...
+# GOOGLE_API_KEY=...
+```
+
+- [ ] **Step 4: Sync dependencies (both dev and camunda extras)**
+
+Run: `uv sync --extra dev --extra camunda`
+Expected: httpx and pyzeebe installed, lock file updated.
+Both extras are needed: `dev` for test tooling (httpx, pytest, etc.) and
+`camunda` for pyzeebe (required by `ZeebeClient` and integration tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml Makefile .env.example uv.lock
+git commit -m "build: add httpx dev dep, integration marker, test-integration target"
+```
+
+---
+
+### Task 2: BPMN Process Model
+
+**Files:**
+- Create: `processes/issue-lifecycle.bpmn`
+- Create: `tests/test_bpmn.py`
+
+- [ ] **Step 1: Write failing tests for the BPMN artifact**
+
+Create `tests/test_bpmn.py`:
+
+```python
+"""Tests for the BPMN process model artifact."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+BPMN_PATH = Path(__file__).resolve().parent.parent / "processes" / "issue-lifecycle.bpmn"
+
+BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+ZEEBE_NS = "http://camunda.org/schema/zeebe/1.0"
+
+EXPECTED_PHASES = ["triage", "design", "planning", "implement", "review", "integrate"]
+
+
+def test_bpmn_file_exists() -> None:
+    assert BPMN_PATH.exists(), f"BPMN file not found at {BPMN_PATH}"
+
+
+def test_bpmn_well_formed_xml() -> None:
+    ET.parse(BPMN_PATH)  # Raises ParseError if malformed
+
+
+def test_bpmn_process_id() -> None:
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    processes = root.findall("bpmn:process", ns)
+    assert len(processes) == 1
+    assert processes[0].get("id") == "issue-lifecycle"
+    assert processes[0].get("isExecutable") == "true"
+
+
+def test_bpmn_zeebe_namespace_declared() -> None:
+    text = BPMN_PATH.read_text()
+    assert ZEEBE_NS in text, "Zeebe extension namespace not declared"
+
+
+def test_bpmn_six_service_tasks() -> None:
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+    tasks = process.findall("bpmn:serviceTask", ns)
+    assert len(tasks) == 6, f"Expected 6 service tasks, got {len(tasks)}"
+
+
+def test_bpmn_task_ids() -> None:
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+    tasks = process.findall("bpmn:serviceTask", ns)
+    task_ids = [t.get("id") for t in tasks]
+    expected_ids = [f"Activity_{phase}" for phase in EXPECTED_PHASES]
+    assert task_ids == expected_ids
+
+
+def test_bpmn_job_types() -> None:
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS, "zeebe": ZEEBE_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+    tasks = process.findall("bpmn:serviceTask", ns)
+    job_types: list[str] = []
+    for task in tasks:
+        ext = task.find("bpmn:extensionElements", ns)
+        assert ext is not None, f"No extensionElements on {task.get('id')}"
+        td = ext.find("zeebe:taskDefinition", ns)
+        assert td is not None, f"No zeebe:taskDefinition on {task.get('id')}"
+        jt = td.get("type")
+        assert jt is not None
+        job_types.append(jt)
+    assert job_types == EXPECTED_PHASES
+
+
+def test_bpmn_sequence_flow_connectivity() -> None:
+    """Verify start -> 6 tasks in order -> end via sequence flows."""
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+
+    # Build adjacency from sequence flows
+    flows: dict[str, str] = {}
+    for sf in process.findall("bpmn:sequenceFlow", ns):
+        src = sf.get("sourceRef")
+        tgt = sf.get("targetRef")
+        assert src is not None and tgt is not None
+        flows[src] = tgt
+
+    # Walk the chain: StartEvent_1 -> ... -> EndEvent_1
+    expected_chain = (
+        ["StartEvent_1"]
+        + [f"Activity_{p}" for p in EXPECTED_PHASES]
+        + ["EndEvent_1"]
+    )
+    for i in range(len(expected_chain) - 1):
+        src = expected_chain[i]
+        assert src in flows, f"No outgoing flow from {src}"
+        assert flows[src] == expected_chain[i + 1], (
+            f"Expected {src} -> {expected_chain[i + 1]}, got {src} -> {flows[src]}"
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_bpmn.py -v`
+Expected: FAIL — `processes/issue-lifecycle.bpmn` does not exist
+
+- [ ] **Step 3: Create the BPMN process model**
+
+Create `processes/issue-lifecycle.bpmn`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_1"
+                  targetNamespace="http://bpmn.io/schema/bpmn"
+                  exporter="sdlc-control-plane"
+                  exporterVersion="0.1.0">
+
+  <bpmn:process id="issue-lifecycle" name="Issue Lifecycle" isExecutable="true">
+
+    <bpmn:startEvent id="StartEvent_1" name="Issue Assigned">
+      <bpmn:outgoing>Flow_start_triage</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:serviceTask id="Activity_triage" name="Triage">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="triage" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_triage</bpmn:incoming>
+      <bpmn:outgoing>Flow_triage_design</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_design" name="Design">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="design" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_triage_design</bpmn:incoming>
+      <bpmn:outgoing>Flow_design_planning</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_planning" name="Planning">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="planning" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_design_planning</bpmn:incoming>
+      <bpmn:outgoing>Flow_planning_implement</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_implement" name="Implement">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="implement" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_planning_implement</bpmn:incoming>
+      <bpmn:outgoing>Flow_implement_review</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_review" name="Review">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="review" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_implement_review</bpmn:incoming>
+      <bpmn:outgoing>Flow_review_integrate</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_integrate" name="Integrate">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="integrate" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_review_integrate</bpmn:incoming>
+      <bpmn:outgoing>Flow_integrate_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:endEvent id="EndEvent_1" name="Issue Complete">
+      <bpmn:incoming>Flow_integrate_end</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_start_triage" sourceRef="StartEvent_1" targetRef="Activity_triage" />
+    <bpmn:sequenceFlow id="Flow_triage_design" sourceRef="Activity_triage" targetRef="Activity_design" />
+    <bpmn:sequenceFlow id="Flow_design_planning" sourceRef="Activity_design" targetRef="Activity_planning" />
+    <bpmn:sequenceFlow id="Flow_planning_implement" sourceRef="Activity_planning" targetRef="Activity_implement" />
+    <bpmn:sequenceFlow id="Flow_implement_review" sourceRef="Activity_implement" targetRef="Activity_review" />
+    <bpmn:sequenceFlow id="Flow_review_integrate" sourceRef="Activity_review" targetRef="Activity_integrate" />
+    <bpmn:sequenceFlow id="Flow_integrate_end" sourceRef="Activity_integrate" targetRef="EndEvent_1" />
+
+  </bpmn:process>
+
+</bpmn:definitions>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_bpmn.py -v`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `uv run pytest -x -q`
+Expected: All existing tests + new BPMN tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add processes/issue-lifecycle.bpmn tests/test_bpmn.py
+git commit -m "feat(s3): add BPMN issue-lifecycle process model with unit tests"
+```
+
+---
+
+## Chunk 2: Orchestration Config and Client
+
+### Task 3: ZeebeConfig
+
+**Files:**
+- Create: `src/sdlc_control_plane/orchestration/config.py`
+- Create: `tests/test_orchestration_config.py`
+
+- [ ] **Step 1: Write failing tests for ZeebeConfig**
+
+Create `tests/test_orchestration_config.py`:
+
+```python
+"""Tests for orchestration configuration."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+
+class TestZeebeConfigDefaults:
+    def test_defaults(self) -> None:
+        config = ZeebeConfig()
+        assert config.zeebe_grpc == "localhost:26500"
+        assert config.zeebe_rest == "http://localhost:8088"
+        assert config.camunda_operate_url == "http://localhost:8088"
+
+    def test_custom_values(self) -> None:
+        config = ZeebeConfig(
+            zeebe_grpc="myhost:26500",
+            zeebe_rest="http://myhost:8088",
+            camunda_operate_url="http://myhost:8088",
+        )
+        assert config.zeebe_grpc == "myhost:26500"
+        assert config.zeebe_rest == "http://myhost:8088"
+
+
+class TestZeebeConfigFromEnv:
+    def test_reads_env_vars(self) -> None:
+        env = {
+            "ZEEBE_GRPC": "remotehost:26500",
+            "ZEEBE_REST": "http://remotehost:8088",
+            "CAMUNDA_OPERATE_URL": "http://remotehost:9090",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = ZeebeConfig.from_env()
+        assert config.zeebe_grpc == "remotehost:26500"
+        assert config.zeebe_rest == "http://remotehost:8088"
+        assert config.camunda_operate_url == "http://remotehost:9090"
+
+    def test_uses_defaults_when_env_absent(self) -> None:
+        env_keys = ["ZEEBE_GRPC", "ZEEBE_REST", "CAMUNDA_OPERATE_URL"]
+        cleaned = {k: v for k, v in os.environ.items() if k not in env_keys}
+        with patch.dict(os.environ, cleaned, clear=True):
+            config = ZeebeConfig.from_env()
+        assert config.zeebe_grpc == "localhost:26500"
+
+    def test_partial_env(self) -> None:
+        with patch.dict(os.environ, {"ZEEBE_GRPC": "custom:9999"}, clear=False):
+            config = ZeebeConfig.from_env()
+        assert config.zeebe_grpc == "custom:9999"
+        assert config.zeebe_rest == "http://localhost:8088"
+
+
+class TestZeebeConfigValidation:
+    def test_zeebe_rest_requires_http_scheme(self) -> None:
+        with pytest.raises(ValidationError, match="zeebe_rest"):
+            ZeebeConfig(zeebe_rest="localhost:8088")
+
+    def test_camunda_operate_url_requires_http_scheme(self) -> None:
+        with pytest.raises(ValidationError, match="camunda_operate_url"):
+            ZeebeConfig(camunda_operate_url="localhost:8088")
+
+    def test_zeebe_rest_accepts_https(self) -> None:
+        config = ZeebeConfig(zeebe_rest="https://secure:8088")
+        assert config.zeebe_rest == "https://secure:8088"
+
+    def test_zeebe_grpc_rejects_http_scheme(self) -> None:
+        with pytest.raises(ValidationError, match="zeebe_grpc"):
+            ZeebeConfig(zeebe_grpc="http://localhost:26500")
+
+    def test_zeebe_grpc_accepts_host_port(self) -> None:
+        config = ZeebeConfig(zeebe_grpc="myhost:26500")
+        assert config.zeebe_grpc == "myhost:26500"
+
+    def test_zeebe_grpc_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ZeebeConfig(zeebe_grpc="")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_orchestration_config.py -v`
+Expected: FAIL — `config.py` module does not exist
+
+- [ ] **Step 3: Implement ZeebeConfig**
+
+Create `src/sdlc_control_plane/orchestration/config.py`:
+
+```python
+"""Zeebe/Camunda connection configuration."""
+
+from __future__ import annotations
+
+import os
+
+from pydantic import BaseModel, field_validator
+
+
+class ZeebeConfig(BaseModel):
+    """Connection settings for Zeebe and Camunda services.
+
+    Use ``from_env()`` to load from environment variables.
+    """
+
+    zeebe_grpc: str = "localhost:26500"
+    zeebe_rest: str = "http://localhost:8088"
+    camunda_operate_url: str = "http://localhost:8088"
+
+    @field_validator("zeebe_grpc")
+    @classmethod
+    def _validate_grpc_address(cls, v: str) -> str:
+        if not v:
+            raise ValueError("zeebe_grpc must not be empty")
+        if v.startswith(("http://", "https://")):
+            raise ValueError(
+                "zeebe_grpc must be host:port without scheme, got: " + v
+            )
+        return v
+
+    @field_validator("zeebe_rest", "camunda_operate_url")
+    @classmethod
+    def _validate_http_url(cls, v: str) -> str:
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("must start with http:// or https://, got: " + v)
+        return v
+
+    @classmethod
+    def from_env(cls) -> ZeebeConfig:
+        """Create config from environment variables with defaults."""
+        kwargs: dict[str, str] = {}
+        env_map = {
+            "ZEEBE_GRPC": "zeebe_grpc",
+            "ZEEBE_REST": "zeebe_rest",
+            "CAMUNDA_OPERATE_URL": "camunda_operate_url",
+        }
+        for env_key, field_name in env_map.items():
+            val = os.environ.get(env_key)
+            if val is not None:
+                kwargs[field_name] = val
+        return cls(**kwargs)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_orchestration_config.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sdlc_control_plane/orchestration/config.py tests/test_orchestration_config.py
+git commit -m "feat(s3): add ZeebeConfig with env var loading and validation"
+```
+
+---
+
+### Task 4: ZeebeClient Facade
+
+**Files:**
+- Create: `src/sdlc_control_plane/orchestration/client.py`
+- Modify: `src/sdlc_control_plane/orchestration/__init__.py`
+- Create: `tests/test_orchestration_client.py`
+
+- [ ] **Step 1: Write failing tests for ZeebeClient**
+
+Create `tests/test_orchestration_client.py`:
+
+```python
+"""Tests for orchestration client facade."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+
+class TestConditionalImport:
+    def test_module_imports_without_pyzeebe(self) -> None:
+        """The orchestration.client module should import cleanly even
+        when pyzeebe is not installed."""
+        # Force-remove pyzeebe from sys.modules for this test
+        saved = {}
+        to_remove = [k for k in sys.modules if k.startswith("pyzeebe")]
+        for k in to_remove:
+            saved[k] = sys.modules.pop(k)
+
+        try:
+            with patch.dict(sys.modules, {"pyzeebe": None, "pyzeebe.channel": None}):
+                # Re-import to test the conditional path
+                import importlib
+                import sdlc_control_plane.orchestration.client as mod
+
+                importlib.reload(mod)
+                # Module should load fine
+                assert hasattr(mod, "ZeebeClient")
+        finally:
+            sys.modules.update(saved)
+
+    def test_constructor_raises_without_pyzeebe(self) -> None:
+        """ZeebeClient() should raise ImportError with install instructions."""
+        saved = {}
+        to_remove = [k for k in sys.modules if k.startswith("pyzeebe")]
+        for k in to_remove:
+            saved[k] = sys.modules.pop(k)
+
+        try:
+            with patch.dict(
+                sys.modules, {"pyzeebe": None, "pyzeebe.channel": None}
+            ):
+                import importlib
+                import sdlc_control_plane.orchestration.client as mod
+
+                importlib.reload(mod)
+                config = ZeebeConfig()
+                with pytest.raises(ImportError, match="uv sync --extra camunda"):
+                    mod.ZeebeClient(config)
+        finally:
+            sys.modules.update(saved)
+
+
+class TestZeebeClientWithMockedPyzeebe:
+    @pytest.fixture()
+    def client(self) -> MagicMock:
+        """Create a ZeebeClient with mocked pyzeebe."""
+        from sdlc_control_plane.orchestration.client import ZeebeClient
+
+        config = ZeebeConfig(zeebe_grpc="localhost:36500")
+        with patch(
+            "sdlc_control_plane.orchestration.client.create_insecure_channel"
+        ) as mock_channel:
+            mock_channel.return_value = MagicMock()
+            zclient = ZeebeClient(config)
+        return zclient
+
+    def test_construction_succeeds(self, client: MagicMock) -> None:
+        assert client is not None
+
+    def test_has_deploy_process(self, client: MagicMock) -> None:
+        assert hasattr(client, "deploy_process")
+        assert callable(client.deploy_process)
+
+    def test_has_create_instance(self, client: MagicMock) -> None:
+        assert hasattr(client, "create_instance")
+        assert callable(client.create_instance)
+
+    def test_has_run_worker(self, client: MagicMock) -> None:
+        assert hasattr(client, "run_worker")
+        assert callable(client.run_worker)
+
+
+class TestDeployProcess:
+    def test_deploy_delegates_to_pyzeebe(self) -> None:
+        from sdlc_control_plane.orchestration.client import (
+            DeploymentResult,
+            ZeebeClient,
+        )
+
+        config = ZeebeConfig(zeebe_grpc="localhost:36500")
+        mock_response = MagicMock()
+        mock_response.deployments = [
+            MagicMock(
+                bpmn_process_id="issue-lifecycle",
+                version=1,
+                process_definition_key=12345,
+            )
+        ]
+
+        with patch(
+            "sdlc_control_plane.orchestration.client.create_insecure_channel"
+        ):
+            client = ZeebeClient(config)
+
+        client._sync_client = MagicMock()
+        client._sync_client.deploy_resource.return_value = mock_response
+
+        result = client.deploy_process(Path("test.bpmn"))
+        assert isinstance(result, DeploymentResult)
+        assert result.process_id == "issue-lifecycle"
+        assert result.version == 1
+        assert result.process_definition_key == 12345
+
+
+class TestCreateInstance:
+    def test_create_instance_delegates_to_pyzeebe(self) -> None:
+        from sdlc_control_plane.orchestration.client import (
+            InstanceResult,
+            ZeebeClient,
+        )
+
+        config = ZeebeConfig(zeebe_grpc="localhost:36500")
+        mock_response = MagicMock()
+        mock_response.process_instance_key = 99999
+        mock_response.process_definition_key = 12345
+
+        with patch(
+            "sdlc_control_plane.orchestration.client.create_insecure_channel"
+        ):
+            client = ZeebeClient(config)
+
+        client._sync_client = MagicMock()
+        client._sync_client.run_process.return_value = mock_response
+
+        result = client.create_instance(
+            "issue-lifecycle", {"issue_id": "TEST-1"}
+        )
+        assert isinstance(result, InstanceResult)
+        assert result.process_instance_key == 99999
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_orchestration_client.py -v`
+Expected: FAIL — `client.py` does not exist
+
+- [ ] **Step 3: Implement ZeebeClient facade**
+
+Create `src/sdlc_control_plane/orchestration/client.py`:
+
+```python
+"""Thin facade over pyzeebe for Camunda/Zeebe interaction."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+# Lazy imports — module loads cleanly without pyzeebe installed.
+# The dependency is checked at ZeebeClient construction time.
+try:
+    from pyzeebe import Job as _Job
+    from pyzeebe import SyncZeebeClient as _SyncZeebeClient
+    from pyzeebe import ZeebeWorker as _ZeebeWorker
+    from pyzeebe.channel import create_insecure_channel
+
+    _PYZEEBE_AVAILABLE = True
+except ImportError:
+    _PYZEEBE_AVAILABLE = False
+
+    # Provide stubs so the module can be imported for type checking
+    create_insecure_channel = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class DeploymentResult:
+    """Result of deploying a BPMN process to Zeebe."""
+
+    process_id: str
+    version: int
+    process_definition_key: int
+
+
+@dataclass(frozen=True)
+class InstanceResult:
+    """Result of starting a process instance."""
+
+    process_instance_key: int
+    process_definition_key: int
+
+
+class ZeebeClient:
+    """Synchronous facade over pyzeebe for Zeebe interaction.
+
+    Requires the ``camunda`` extra to be installed. If pyzeebe is not
+    available, the constructor raises ``ImportError`` with install
+    instructions.
+    """
+
+    def __init__(self, config: ZeebeConfig) -> None:
+        if not _PYZEEBE_AVAILABLE:
+            raise ImportError(
+                "pyzeebe is required. Install with: uv sync --extra camunda"
+            )
+        self._config = config
+        self._channel = create_insecure_channel(
+            grpc_address=config.zeebe_grpc
+        )
+        self._sync_client = _SyncZeebeClient(grpc_channel=self._channel)
+
+    def deploy_process(self, bpmn_path: Path) -> DeploymentResult:
+        """Deploy a BPMN file to Zeebe."""
+        response = self._sync_client.deploy_resource(str(bpmn_path))
+        proc = response.deployments[0]
+        return DeploymentResult(
+            process_id=proc.bpmn_process_id,
+            version=proc.version,
+            process_definition_key=proc.process_definition_key,
+        )
+
+    def create_instance(
+        self, process_id: str, variables: dict[str, Any] | None = None
+    ) -> InstanceResult:
+        """Start a workflow instance."""
+        response = self._sync_client.run_process(
+            bpmn_process_id=process_id, variables=variables
+        )
+        return InstanceResult(
+            process_instance_key=response.process_instance_key,
+            process_definition_key=response.process_definition_key,
+        )
+
+    def run_worker(
+        self,
+        job_type: str,
+        handler: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
+        timeout: float = 30.0,
+        max_jobs: int = 1,
+    ) -> list[str]:
+        """Run a worker that processes jobs of the given type.
+
+        Lifecycle: activates and completes up to ``max_jobs`` jobs of the
+        given type, then stops. If fewer than ``max_jobs`` arrive before
+        ``timeout`` seconds, returns with whatever was completed.
+
+        Args:
+            job_type: Zeebe job type to handle.
+            handler: Called with job variables dict. Return dict is
+                merged into output variables. If None, jobs are
+                auto-completed with no output.
+            timeout: Max seconds to wait for jobs.
+            max_jobs: Stop after completing this many jobs. Default 1.
+
+        Returns:
+            List of completed job types (for order verification).
+
+        Note: pyzeebe auto-calls set_success_status() after the
+        handler returns -- do NOT call it manually.
+        """
+        completed: list[str] = []
+
+        async def _run() -> list[str]:
+            # Create a fresh channel for the worker's event loop.
+            # Cannot share the SyncZeebeClient's channel across
+            # event loop boundaries.
+            channel = create_insecure_channel(
+                grpc_address=self._config.zeebe_grpc
+            )
+            worker = _ZeebeWorker(grpc_channel=channel)
+
+            @worker.task(task_type=job_type)
+            async def _handle(job: _Job) -> dict[str, Any]:
+                result: dict[str, Any] = {}
+                if handler is not None:
+                    out = handler(job.variables)
+                    if out is not None:
+                        result = out
+                completed.append(job.type)
+                return result
+
+            worker_task = asyncio.create_task(worker.work())
+            try:
+                deadline = asyncio.get_event_loop().time() + timeout
+                while len(completed) < max_jobs:
+                    if asyncio.get_event_loop().time() > deadline:
+                        break
+                    await asyncio.sleep(0.2)
+            finally:
+                await worker.stop()
+                worker_task.cancel()
+                try:
+                    await worker_task
+                except asyncio.CancelledError:
+                    pass
+            return completed
+
+        asyncio.run(_run())
+        return completed
+```
+
+- [ ] **Step 4: Update `orchestration/__init__.py` with re-exports**
+
+Replace the empty `src/sdlc_control_plane/orchestration/__init__.py` with:
+
+```python
+"""Delivery Orchestration — Camunda/Zeebe client and workflow interaction."""
+
+from sdlc_control_plane.orchestration.client import (
+    DeploymentResult,
+    InstanceResult,
+    ZeebeClient,
+)
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+__all__ = [
+    "DeploymentResult",
+    "InstanceResult",
+    "ZeebeClient",
+    "ZeebeConfig",
+]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_orchestration_client.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run pytest -x -q`
+Expected: All tests pass (existing + new config + client + BPMN)
+
+- [ ] **Step 7: Run lint and type checks**
+
+Run: `uv run ruff check src/sdlc_control_plane/orchestration/ tests/test_orchestration_config.py tests/test_orchestration_client.py tests/test_bpmn.py`
+Run: `uv run mypy src/sdlc_control_plane/orchestration/`
+Expected: No errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/sdlc_control_plane/orchestration/ tests/test_orchestration_client.py
+git commit -m "feat(s3): add ZeebeClient facade with deploy, start, and worker support"
+```
+
+---
+
+## Chunk 3: Integration Tests
+
+### Task 5: Integration Test Infrastructure
+
+**Files:**
+- Modify: `tests/conftest.py`
+
+- [ ] **Step 1: Read existing conftest.py**
+
+Check `tests/conftest.py` for any existing fixtures to avoid conflicts.
+
+- [ ] **Step 2: Add integration fixtures**
+
+Add to `tests/conftest.py` (or create if it doesn't exist):
+
+```python
+"""Shared test fixtures."""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Generator
+
+import pytest
+
+# CI cluster defaults (unauthenticated, for automated testing)
+CI_ZEEBE_GRPC = "localhost:36500"
+CI_CAMUNDA_REST = "http://localhost:18088"
+
+
+def _check_tcp(host: str, port: int, timeout: float = 2.0) -> bool:
+    """Check if a TCP port is reachable."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _check_http(url: str, timeout: float = 2.0) -> bool:
+    """Check if an HTTP endpoint returns a non-error response."""
+    try:
+        import httpx
+
+        resp = httpx.get(f"{url}/v2/topology", timeout=timeout)
+        return resp.status_code < 500
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="session")
+def zeebe_grpc_address() -> str:
+    """Zeebe gRPC address for integration tests."""
+    return os.environ.get("ZEEBE_GRPC", CI_ZEEBE_GRPC)
+
+
+@pytest.fixture(scope="session")
+def camunda_rest_url() -> str:
+    """Camunda REST API base URL for integration tests.
+
+    In Camunda 8.8's consolidated image, the Zeebe REST API and
+    Operate share the same base URL. We use ZEEBE_REST (not
+    CAMUNDA_OPERATE_URL) because the /v2/process-instances/search
+    endpoint is part of the Zeebe REST API, not Operate's UI API.
+    The env var fallback chain: ZEEBE_REST -> CI cluster default.
+    """
+    return os.environ.get("ZEEBE_REST", CI_CAMUNDA_REST)
+
+
+@pytest.fixture(scope="session")
+def zeebe_available(zeebe_grpc_address: str, camunda_rest_url: str) -> None:
+    """Skip test if the Camunda CI cluster is not reachable.
+
+    Checks both Zeebe gRPC and the Camunda REST API.
+    """
+    host, port_str = zeebe_grpc_address.rsplit(":", 1)
+    if not _check_tcp(host, int(port_str)):
+        pytest.skip(
+            f"Zeebe gRPC not reachable at {zeebe_grpc_address}"
+        )
+    if not _check_http(camunda_rest_url):
+        pytest.skip(
+            f"Camunda REST API not reachable at {camunda_rest_url}"
+        )
+
+
+@pytest.fixture()
+def instance_cleanup(zeebe_grpc_address: str) -> Generator[list[int], None, None]:
+    """Best-effort cancel of test process instances on teardown.
+
+    Append instance keys to the yielded list during the test.
+    On teardown, attempts to cancel each. Does not fail if already
+    completed or gone.
+    """
+    keys: list[int] = []
+    yield keys
+    if not keys:
+        return
+    try:
+        from pyzeebe import SyncZeebeClient
+        from pyzeebe.channel import create_insecure_channel
+
+        channel = create_insecure_channel(grpc_address=zeebe_grpc_address)
+        client = SyncZeebeClient(grpc_channel=channel)
+        for key in keys:
+            try:
+                client.cancel_process_instance(key)
+            except Exception:
+                pass  # Already completed or gone
+    except ImportError:
+        pass
+```
+
+- [ ] **Step 3: Verify fixtures don't break existing tests**
+
+Run: `uv run pytest -x -q`
+Expected: All existing tests still pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/conftest.py
+git commit -m "test(s3): add integration fixtures for Camunda CI cluster"
+```
+
+---
+
+### Task 6: Integration Test — Happy Path
+
+**Files:**
+- Create: `tests/test_workflow_integration.py`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/test_workflow_integration.py`:
+
+```python
+"""Integration test: issue-lifecycle happy path against live Camunda cluster.
+
+Requires the Camunda CI cluster to be running (docker-compose-ci.yaml).
+Skipped automatically if the cluster is not reachable.
+
+Tests the full public facade: deploy_process, create_instance, run_worker.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from sdlc_control_plane.orchestration.client import ZeebeClient
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+BPMN_PATH = Path(__file__).resolve().parent.parent / "processes" / "issue-lifecycle.bpmn"
+
+EXPECTED_PHASES = ["triage", "design", "planning", "implement", "review", "integrate"]
+
+
+@pytest.fixture()
+def zeebe_client(
+    zeebe_available: None, zeebe_grpc_address: str
+) -> ZeebeClient:
+    """Create a ZeebeClient connected to the CI cluster."""
+    config = ZeebeConfig(zeebe_grpc=zeebe_grpc_address)
+    return ZeebeClient(config)
+
+
+@pytest.fixture()
+def _deploy_process(zeebe_client: ZeebeClient) -> None:
+    """Deploy the issue-lifecycle BPMN to Zeebe."""
+    zeebe_client.deploy_process(BPMN_PATH)
+
+
+def _poll_instance_completed(
+    rest_url: str,
+    instance_key: int,
+    timeout: float = 10.0,
+    interval: float = 1.0,
+) -> str:
+    """Poll Camunda REST API until instance reaches a terminal state.
+
+    Uses ``zeebe_rest`` (the Zeebe REST API), not Operate. In the
+    consolidated Camunda 8.8 image both are the same endpoint, but
+    semantically this is querying the Zeebe-backed process instance
+    search, not the Operate UI API.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = httpx.post(
+            f"{rest_url}/v2/process-instances/search",
+            json={
+                "filter": {"processInstanceKey": instance_key},
+            },
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            items = data.get("items", [])
+            if items:
+                state = items[0].get("state", "")
+                if state in ("COMPLETED", "CANCELED", "TERMINATED"):
+                    return state
+        time.sleep(interval)
+    raise TimeoutError(
+        f"Instance {instance_key} did not reach terminal state within {timeout}s"
+    )
+
+
+@pytest.mark.integration
+class TestIssueLifecycleHappyPath:
+    def test_workflow_completes_all_phases(
+        self,
+        zeebe_client: ZeebeClient,
+        camunda_rest_url: str,
+        instance_cleanup: list[int],
+        _deploy_process: None,
+    ) -> None:
+        """Deploy, start, drive all 6 phases via facade, verify completion.
+
+        Uses ZeebeClient.run_worker() for each phase sequentially.
+        The process is sequential, so each phase's job only becomes
+        available after the previous one completes.
+        """
+        # Start instance via facade
+        result = zeebe_client.create_instance(
+            "issue-lifecycle",
+            {"issue_id": "TEST-1", "issue_type": "Implementation"},
+        )
+        instance_key = result.process_instance_key
+        assert instance_key > 0
+        instance_cleanup.append(instance_key)
+
+        # Drive all 6 phases sequentially through the facade.
+        # Each run_worker call processes exactly 1 job of the given
+        # type, then returns. The process is sequential so each
+        # phase's job only appears after the prior one completes.
+        completed: list[str] = []
+        for phase in EXPECTED_PHASES:
+            result_types = zeebe_client.run_worker(
+                job_type=phase, timeout=10.0, max_jobs=1
+            )
+            completed.extend(result_types)
+
+        # Assert ordering
+        assert completed == EXPECTED_PHASES, (
+            f"Expected {EXPECTED_PHASES}, got {completed}"
+        )
+
+        # Assert completed state via Camunda REST API.
+        # Uses camunda_rest_url which points to the Zeebe REST API
+        # on the CI cluster (localhost:18088). The /v2/ endpoints are
+        # served by the consolidated Camunda image, not a separate
+        # Operate instance.
+        state = _poll_instance_completed(camunda_rest_url, instance_key)
+        assert state == "COMPLETED", f"Expected COMPLETED, got {state}"
+```
+
+- [ ] **Step 2: Run integration test against CI cluster**
+
+Run: `uv run pytest tests/test_workflow_integration.py -v -m integration`
+Expected: 1 test PASS (if CI cluster is running) or SKIP (if not)
+
+- [ ] **Step 3: Verify default test suite skips integration tests gracefully**
+
+Run: `uv run pytest -x -q`
+Expected: All tests pass; integration test either runs and passes or is
+skipped with "Zeebe gRPC not reachable" message
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_workflow_integration.py
+git commit -m "test(s3): add integration test for issue-lifecycle happy path"
+```
+
+---
+
+## Chunk 4: Final Verification
+
+### Task 7: Full Suite Verification and Cleanup
+
+- [ ] **Step 1: Run full quality check**
+
+Run: `make check`
+Expected: lint + typecheck + tests all pass
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `make test-integration`
+Expected: Happy path test passes against CI cluster
+
+- [ ] **Step 3: Verify the BPMN process in Operate (manual check)**
+
+Open `http://localhost:18088` in browser or use:
+
+```bash
+curl -s http://localhost:18088/v2/process-definitions/search \
+  -X POST -H 'Content-Type: application/json' \
+  -d '{"filter":{"bpmnProcessId":"issue-lifecycle"}}' | python3 -m json.tool
+```
+
+Expected: The `issue-lifecycle` process definition appears (version will
+increment on each deploy — the important thing is the definition exists
+and has the correct `bpmnProcessId`).
+
+- [ ] **Step 4: Fix any issues found, re-run checks**
+
+If any failures: fix, re-run `make check` and `make test-integration`.
+
+- [ ] **Step 5: Final commit if any cleanup was needed**
+
+```bash
+git add -u
+git commit -m "refactor(s3): address lint/type/test findings"
+```

--- a/docs/superpowers/specs/2026-03-11-s3-minimal-bpmn-process-design.md
+++ b/docs/superpowers/specs/2026-03-11-s3-minimal-bpmn-process-design.md
@@ -1,0 +1,275 @@
+# S3: Minimal BPMN Process (Happy Path) — Design Spec
+
+> Session 3 of the SDLC Control Plane implementation roadmap.
+> Goal: Deploy a minimal BPMN process to Camunda and prove the full 6-phase
+> happy path completes via Operate.
+
+---
+
+## 1. Scope
+
+### In Scope
+
+- Hand-authored BPMN 2.0 process model for the issue lifecycle happy path
+- Thin pyzeebe-based orchestration facade with conditional imports
+- ZeebeConfig Pydantic model matching the repo's `.env.example` contract
+- Unit tests for config, client facade, and BPMN artifact correctness
+- Integration tests proving workflow completion against the live Camunda cluster
+
+### Out of Scope (deferred to later sessions)
+
+- Transition gating / gate evaluation (S4)
+- WorkflowEvent emission (S4)
+- User tasks, embedded subprocesses, timers, escalation
+- Competitive review / dispute handling (S7-S8)
+- Certificate semantics in Camunda
+- Remediation loops (S9)
+
+---
+
+## 2. BPMN Process Model
+
+**File:** `processes/issue-lifecycle.bpmn`
+
+**Process ID:** `issue-lifecycle`
+
+**Shape:** Single sequential process with 6 service tasks.
+
+```
+StartEvent_1
+  -> Activity_triage    (job type: "triage")
+  -> Activity_design    (job type: "design")
+  -> Activity_planning  (job type: "planning")
+  -> Activity_implement (job type: "implement")
+  -> Activity_review    (job type: "review")
+  -> Activity_integrate (job type: "integrate")
+  -> EndEvent_1
+```
+
+### Design Decisions
+
+- **All phases are service tasks in S3.** The lifecycle spec maps some phases to
+  user tasks and embedded subprocesses, but S3 needs a fully automatable happy
+  path driven by job workers. The richer task types are S4+ evolution.
+
+- **Static BPMN element IDs.** Element IDs identify nodes in the process
+  definition, not runtime instances. `issue_id` belongs in process variables,
+  not element IDs. IDs follow the `Activity_{phase}` convention aligned with
+  Section 10 of the lifecycle spec.
+
+- **Zeebe extension namespace required.** The BPMN XML must include the Zeebe
+  extension namespace (`zeebe:taskDefinition`) for each service task so the
+  process is executable, not just structurally valid.
+
+### Process Variables (at start)
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `issue_id` | string | Identifier for the issue being processed |
+| `issue_type` | string | Issue type (e.g., "Implementation", "Contract") |
+
+Minimal set for S3. Later sessions extend with `milestone`, `assignee_role`,
+`epic_branch`, etc. per Section 10 of the lifecycle spec.
+
+---
+
+## 3. Orchestration Module
+
+### File Structure
+
+```
+src/sdlc_control_plane/orchestration/
+    __init__.py     # Re-exports ZeebeConfig, ZeebeClient
+    config.py       # ZeebeConfig Pydantic model
+    client.py       # ZeebeClient facade over pyzeebe
+```
+
+### `config.py` — ZeebeConfig
+
+A plain `pydantic.BaseModel` with a `from_env()` classmethod that reads
+`os.environ`. Not `pydantic-settings.BaseSettings` (that package is not a
+project dependency).
+
+| Field | Type | Default | Env Var | Notes |
+|-------|------|---------|---------|-------|
+| `zeebe_grpc` | `str` | `"localhost:26500"` | `ZEEBE_GRPC` | host:port, NOT a URL |
+| `zeebe_rest` | `str` | `"http://localhost:8088"` | `ZEEBE_REST` | HTTP URL |
+| `camunda_operate_url` | `str` | `"http://localhost:8088"` | `CAMUNDA_OPERATE_URL` | HTTP URL |
+
+Validation:
+- `zeebe_rest` and `camunda_operate_url` must start with `http://` or `https://`
+- `zeebe_grpc` is validated as `host:port` format (no scheme)
+
+#### Cluster Authentication
+
+The local infrastructure has two Camunda clusters:
+- **Main cluster** (ports 26500/8088): requires authentication (returns 401
+  on unauthenticated REST calls). Used for interactive development.
+- **CI cluster** (ports 36500/18088): unauthenticated (`unprotectedApi: true`).
+  Designed for automated testing.
+
+S3 integration tests target the **CI cluster**. The test fixtures use env
+vars to connect, defaulting to CI cluster ports. The `.env.example` defaults
+remain pointed at the main cluster (for interactive CLI use), but integration
+test fixtures override with CI cluster values.
+
+Auth support (for the main cluster) is deferred — not needed for S3.
+
+### `client.py` — ZeebeClient
+
+The `pyzeebe` dependency is checked lazily, not at module import time. The
+module itself imports cleanly even without the `camunda` extra installed.
+The dependency check happens when `ZeebeClient` is **constructed** — if
+`pyzeebe` is not available, the constructor raises `ImportError` with:
+`"pyzeebe is required. Install with: uv sync --extra camunda"`
+
+This keeps the `orchestration` package importable for tests, docs, and
+type checking on machines without `pyzeebe` installed. Only actual use
+of the Zeebe client triggers the dependency requirement.
+
+**Constructor:** `ZeebeClient(config: ZeebeConfig)`
+
+#### Async Strategy
+
+pyzeebe 4.x provides both `ZeebeClient` (async) and `SyncZeebeClient`
+(sync wrapper). `ZeebeWorker` is async-only — there is no sync equivalent.
+
+Our facade uses **`SyncZeebeClient`** for `deploy_process` and
+`create_instance` (simple request-response operations that don't need
+async). For `run_worker`, which requires the async `ZeebeWorker`, the
+facade wraps the worker loop in `asyncio.run()`.
+
+Important: the worker creates a **separate** `grpc.aio.Channel` inside
+`asyncio.run()` — it cannot share the `SyncZeebeClient`'s channel across
+event loop boundaries.
+
+S3 does **not** support being called from within an already-running event
+loop. If that becomes necessary in later sessions, the facade can expose
+async variants alongside the sync API.
+
+**Methods:**
+
+#### `deploy_process(bpmn_path: Path) -> DeploymentResult`
+Deploy a BPMN file to Zeebe. Returns deployment metadata (process definition
+key). Internally delegates to pyzeebe's `deploy_resource()`.
+
+#### `create_instance(process_id: str, variables: dict) -> InstanceResult`
+Start a workflow instance. Returns instance key. Internally delegates to
+pyzeebe's `run_process()`.
+
+#### `run_worker(job_type: str, handler: Callable | None = None, timeout: float = 30.0) -> list[str]`
+Register a worker for the given job type. Behavior:
+- Processes jobs of the given type until no more matching work remains or
+  `timeout` seconds elapse, then returns.
+- If `handler` is `None`, auto-completes each job (S3 happy path).
+- If `handler` is provided, calls it with the job variables.
+- Returns a list of completed job types (for order verification in tests).
+- Deterministic for the sequential S3 process: each job type appears exactly
+  once per instance.
+
+#### Multi-Phase Worker Orchestration
+
+The S3 integration test needs to complete all 6 sequential job types. The
+six-phase orchestration logic lives in the **integration test layer**, not
+in the public `ZeebeClient` API. The test registers all 6 task handlers on
+a single `ZeebeWorker` instance (via `run_worker`), runs the worker until
+all 6 have fired or timeout is reached, and each handler appends its job
+type to a shared completion list for order verification.
+
+The public `ZeebeClient` API stays minimal: `deploy_process`,
+`create_instance`, `run_worker`. No `run_happy_path` convenience method
+on the client — that would be a test-shaped method on the library surface.
+
+**Result types:** `DeploymentResult` and `InstanceResult` are simple Pydantic
+models (or dataclasses) holding the key fields returned by Zeebe.
+
+---
+
+## 4. Testing Strategy
+
+### Unit Tests (`make test`)
+
+#### `tests/test_orchestration_config.py`
+- `ZeebeConfig.from_env()` reads env vars correctly
+- Defaults applied when env vars are absent
+- Validation rejects malformed values (e.g., `zeebe_rest` without `http://`)
+- `zeebe_grpc` accepts `host:port` format without scheme
+
+#### `tests/test_orchestration_client.py`
+- Clear `ImportError` message when `pyzeebe` is not installed
+- Successful `ZeebeClient` construction when `pyzeebe` is available (mocked)
+- Facade methods exist and delegate correctly (mock pyzeebe, don't test its internals)
+
+#### `tests/test_bpmn.py`
+- BPMN file exists at `processes/issue-lifecycle.bpmn`
+- XML is well-formed
+- Process ID is `issue-lifecycle`
+- Contains exactly 6 activity elements, all are service tasks
+- Each service task has a Zeebe `taskDefinition` with the correct job type
+- Job types are exactly: `triage`, `design`, `planning`, `implement`, `review`, `integrate`
+- Sequence flows connect: StartEvent_1 -> 6 tasks in order -> EndEvent_1
+- Zeebe extension namespace is declared
+
+### Integration Tests (`make test-integration`, `@pytest.mark.integration`)
+
+#### `tests/test_workflow_integration.py`
+1. Deploy `processes/issue-lifecycle.bpmn` to Zeebe (CI cluster)
+2. Start instance with `{issue_id: "TEST-1", issue_type: "Implementation"}`
+3. Workers record observed job completion order, then auto-complete
+4. Assert observed order equals `["triage", "design", "planning", "implement", "review", "integrate"]`
+5. Assert instance reached completed state via Camunda REST API
+   (`POST /v2/process-instances/search` with filter on `processInstanceKey`).
+   Uses polling with retry (up to 10s, 1s intervals) to account for
+   Elasticsearch indexing delay between Zeebe completion and search
+   API reflecting the state.
+
+#### `tests/conftest.py` — Integration Fixtures
+- `zeebe_available` fixture: checks both Zeebe gRPC reachability (CI cluster,
+  default `localhost:36500`) AND Camunda REST API reachability (CI cluster,
+  default `http://localhost:18088`). Skips gracefully if either is unavailable.
+- CI cluster connection defaults are hardcoded in the fixture but overridable
+  via `ZEEBE_GRPC` and `CAMUNDA_OPERATE_URL` env vars.
+- Cleanup fixture: best-effort cancel of test instances on teardown. Does not
+  fail if instance already completed or is gone.
+
+### Configuration Additions
+
+**`pyproject.toml`:**
+```toml
+[tool.pytest.ini_options]
+markers = ["integration: requires live Camunda cluster"]
+```
+
+**`Makefile`:**
+```makefile
+test-integration:
+	uv run pytest -m integration -v
+```
+
+---
+
+## 5. Dependencies
+
+No new required dependencies. `pyzeebe>=4.0` is already in the `[camunda]`
+optional extra.
+
+Add to `[dev]` extras:
+- `httpx>=0.27` — for Camunda REST API queries in integration tests
+  (completion state polling).
+
+`pytest-asyncio` is **not** added for S3. The sync facade wraps all async
+internally via `asyncio.run()`, so tests are plain synchronous pytest.
+
+Integration tests are collected by `make test` but gracefully skipped via
+the `zeebe_available` fixture when the Camunda cluster is unreachable. No
+change to the default `make test` target is required.
+
+---
+
+## 6. Success Criterion
+
+> "Workflow completes in Operate"
+
+Proven by: integration test that deploys `issue-lifecycle.bpmn`, starts an
+instance, drives all 6 phases via workers, records the completion order, and
+verifies the instance reached completed state through the Operate REST API.

--- a/processes/issue-lifecycle.bpmn
+++ b/processes/issue-lifecycle.bpmn
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+                  id="Definitions_1"
+                  targetNamespace="http://bpmn.io/schema/bpmn"
+                  exporter="sdlc-control-plane"
+                  exporterVersion="0.1.0">
+
+  <bpmn:process id="issue-lifecycle" name="Issue Lifecycle" isExecutable="true">
+
+    <bpmn:startEvent id="StartEvent_1" name="Issue Assigned">
+      <bpmn:outgoing>Flow_start_triage</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:serviceTask id="Activity_triage" name="Triage">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="triage" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_triage</bpmn:incoming>
+      <bpmn:outgoing>Flow_triage_design</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_design" name="Design">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="design" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_triage_design</bpmn:incoming>
+      <bpmn:outgoing>Flow_design_planning</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_planning" name="Planning">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="planning" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_design_planning</bpmn:incoming>
+      <bpmn:outgoing>Flow_planning_implement</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_implement" name="Implement">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="implement" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_planning_implement</bpmn:incoming>
+      <bpmn:outgoing>Flow_implement_review</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_review" name="Review">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="review" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_implement_review</bpmn:incoming>
+      <bpmn:outgoing>Flow_review_integrate</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:serviceTask id="Activity_integrate" name="Integrate">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="integrate" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_review_integrate</bpmn:incoming>
+      <bpmn:outgoing>Flow_integrate_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+
+    <bpmn:endEvent id="EndEvent_1" name="Issue Complete">
+      <bpmn:incoming>Flow_integrate_end</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_start_triage" sourceRef="StartEvent_1" targetRef="Activity_triage" />
+    <bpmn:sequenceFlow id="Flow_triage_design" sourceRef="Activity_triage" targetRef="Activity_design" />
+    <bpmn:sequenceFlow id="Flow_design_planning" sourceRef="Activity_design" targetRef="Activity_planning" />
+    <bpmn:sequenceFlow id="Flow_planning_implement" sourceRef="Activity_planning" targetRef="Activity_implement" />
+    <bpmn:sequenceFlow id="Flow_implement_review" sourceRef="Activity_implement" targetRef="Activity_review" />
+    <bpmn:sequenceFlow id="Flow_review_integrate" sourceRef="Activity_review" targetRef="Activity_integrate" />
+    <bpmn:sequenceFlow id="Flow_integrate_end" sourceRef="Activity_integrate" targetRef="EndEvent_1" />
+
+  </bpmn:process>
+
+</bpmn:definitions>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,15 @@ warn_return_any = true
 warn_unused_configs = true
 mypy_path = "src"
 
+[[tool.mypy.overrides]]
+module = ["pyzeebe.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["sdlc_control_plane.orchestration.client"]
+warn_unused_ignores = false
+disallow_untyped_decorators = false
+
 [tool.ruff]
 target-version = "py310"
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "hypothesis>=6.90",
     "mypy>=1.8",
     "ruff>=0.3",
+    "httpx>=0.27",
 ]
 
 [project.scripts]
@@ -46,6 +47,8 @@ packages = ["src/sdlc_control_plane"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+markers = ["integration: requires live Camunda cluster"]
+addopts = "-m 'not integration'"
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/sdlc_control_plane/orchestration/__init__.py
+++ b/src/sdlc_control_plane/orchestration/__init__.py
@@ -1,0 +1,15 @@
+"""Delivery Orchestration -- Camunda/Zeebe client and workflow interaction."""
+
+from sdlc_control_plane.orchestration.client import (
+    DeploymentResult,
+    InstanceResult,
+    ZeebeClient,
+)
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+__all__ = [
+    "DeploymentResult",
+    "InstanceResult",
+    "ZeebeClient",
+    "ZeebeConfig",
+]

--- a/src/sdlc_control_plane/orchestration/client.py
+++ b/src/sdlc_control_plane/orchestration/client.py
@@ -1,0 +1,155 @@
+"""Thin facade over pyzeebe for Camunda/Zeebe interaction."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+# Lazy imports -- module loads cleanly without pyzeebe installed.
+# The dependency is checked at ZeebeClient construction time.
+try:
+    from pyzeebe import Job as _Job
+    from pyzeebe import SyncZeebeClient as _SyncZeebeClient
+    from pyzeebe import ZeebeWorker as _ZeebeWorker
+    from pyzeebe.channel import create_insecure_channel
+
+    _PYZEEBE_AVAILABLE = True
+except ImportError:
+    _PYZEEBE_AVAILABLE = False
+
+    # Provide stubs so the module can be imported for type checking
+    create_insecure_channel = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class DeploymentResult:
+    """Result of deploying a BPMN process to Zeebe."""
+
+    process_id: str
+    version: int
+    process_definition_key: int
+
+
+@dataclass(frozen=True)
+class InstanceResult:
+    """Result of starting a process instance."""
+
+    process_instance_key: int
+    process_definition_key: int
+
+
+class ZeebeClient:
+    """Synchronous facade over pyzeebe for Zeebe interaction.
+
+    Requires the ``camunda`` extra to be installed.  If pyzeebe is not
+    available, the constructor raises ``ImportError`` with install
+    instructions.
+    """
+
+    def __init__(self, config: ZeebeConfig) -> None:
+        if not _PYZEEBE_AVAILABLE:
+            raise ImportError(
+                "pyzeebe is required. Install with: uv sync --extra camunda"
+            )
+        self._config = config
+        self._channel = create_insecure_channel(
+            grpc_address=config.zeebe_grpc
+        )
+        self._sync_client = _SyncZeebeClient(grpc_channel=self._channel)
+
+    def deploy_process(self, bpmn_path: Path) -> DeploymentResult:
+        """Deploy a BPMN file to Zeebe."""
+        response = self._sync_client.deploy_resource(str(bpmn_path))
+        # We always deploy BPMN, so the first deployment is ProcessMetadata.
+        proc: Any = response.deployments[0]
+        return DeploymentResult(
+            process_id=proc.bpmn_process_id,
+            version=proc.version,
+            process_definition_key=proc.process_definition_key,
+        )
+
+    def create_instance(
+        self, process_id: str, variables: dict[str, Any] | None = None
+    ) -> InstanceResult:
+        """Start a workflow instance."""
+        response = self._sync_client.run_process(
+            bpmn_process_id=process_id, variables=variables
+        )
+        return InstanceResult(
+            process_instance_key=response.process_instance_key,
+            process_definition_key=response.process_definition_key,
+        )
+
+    def run_worker(
+        self,
+        job_type: str,
+        handler: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
+        timeout: float = 30.0,
+        max_jobs: int = 1,
+    ) -> list[str]:
+        """Run a worker that processes jobs of the given type.
+
+        Lifecycle: activates and completes up to ``max_jobs`` jobs of the
+        given type, then stops.  If fewer than ``max_jobs`` arrive before
+        ``timeout`` seconds, returns with whatever was completed.
+
+        Args:
+            job_type: Zeebe job type to handle.
+            handler: Called with job variables dict.  Return dict is
+                merged into output variables.  If *None*, jobs are
+                auto-completed with no output.
+            timeout: Max seconds to wait for jobs.
+            max_jobs: Stop after completing this many jobs.  Default 1.
+
+        Returns:
+            List of completed job types (for order verification).
+
+        Note:
+            pyzeebe auto-calls ``set_success_status()`` after the
+            handler returns -- do NOT call it manually.
+        """
+        completed: list[str] = []
+
+        async def _run() -> list[str]:
+            # Create a fresh channel for the worker's event loop.
+            # Cannot share the SyncZeebeClient's channel across
+            # event loop boundaries.
+            channel = create_insecure_channel(
+                grpc_address=self._config.zeebe_grpc
+            )
+            worker = _ZeebeWorker(grpc_channel=channel)
+
+            @worker.task(task_type=job_type)  # type: ignore[arg-type]
+            async def _handle(job: _Job) -> dict[str, Any]:
+                result: dict[str, Any] = {}
+                if handler is not None:
+                    out = handler(dict(job.variables))
+                    if out is not None:
+                        result = out
+                completed.append(job.type)
+                return result
+
+            worker_task = asyncio.create_task(worker.work())
+            try:
+                deadline = asyncio.get_event_loop().time() + timeout
+                while len(completed) < max_jobs:
+                    if asyncio.get_event_loop().time() > deadline:
+                        break
+                    await asyncio.sleep(0.2)
+            finally:
+                await worker.stop()
+                worker_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await worker_task
+            return completed
+
+        asyncio.run(_run())
+        return completed

--- a/src/sdlc_control_plane/orchestration/client.py
+++ b/src/sdlc_control_plane/orchestration/client.py
@@ -128,13 +128,18 @@ class ZeebeClient:
             worker = _ZeebeWorker(grpc_channel=channel)
 
             @worker.task(task_type=job_type)  # type: ignore[arg-type]
-            async def _handle(job: _Job) -> dict[str, Any]:
+            async def _handle(**kwargs: Any) -> dict[str, Any]:
+                # ``from __future__ import annotations`` turns all type hints
+                # into strings, so we cannot use a ``Job``-annotated parameter
+                # here -- pyzeebe's introspection would not recognise it.
+                # Instead accept **kwargs (all job variables) and use the
+                # outer ``job_type`` closure variable to record completion.
                 result: dict[str, Any] = {}
                 if handler is not None:
-                    out = handler(dict(job.variables))
+                    out = handler(kwargs)
                     if out is not None:
                         result = out
-                completed.append(job.type)
+                completed.append(job_type)
                 return result
 
             worker_task = asyncio.create_task(worker.work())

--- a/src/sdlc_control_plane/orchestration/client.py
+++ b/src/sdlc_control_plane/orchestration/client.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 # Lazy imports -- module loads cleanly without pyzeebe installed.
 # The dependency is checked at ZeebeClient construction time.
 try:
-    from pyzeebe import Job as _Job
     from pyzeebe import SyncZeebeClient as _SyncZeebeClient
     from pyzeebe import ZeebeWorker as _ZeebeWorker
     from pyzeebe.channel import create_insecure_channel
@@ -143,10 +142,11 @@ class ZeebeClient:
                 return result
 
             worker_task = asyncio.create_task(worker.work())
+            loop = asyncio.get_running_loop()
             try:
-                deadline = asyncio.get_event_loop().time() + timeout
+                deadline = loop.time() + timeout
                 while len(completed) < max_jobs:
-                    if asyncio.get_event_loop().time() > deadline:
+                    if loop.time() > deadline:
                         break
                     await asyncio.sleep(0.2)
             finally:
@@ -154,7 +154,7 @@ class ZeebeClient:
                 worker_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await worker_task
+                await channel.close()
             return completed
 
-        asyncio.run(_run())
-        return completed
+        return asyncio.run(_run())

--- a/src/sdlc_control_plane/orchestration/config.py
+++ b/src/sdlc_control_plane/orchestration/config.py
@@ -1,0 +1,51 @@
+"""Zeebe/Camunda connection configuration."""
+
+from __future__ import annotations
+
+import os
+
+from pydantic import BaseModel, field_validator
+
+
+class ZeebeConfig(BaseModel):
+    """Connection settings for Zeebe and Camunda services.
+
+    Use ``from_env()`` to load from environment variables.
+    """
+
+    zeebe_grpc: str = "localhost:26500"
+    zeebe_rest: str = "http://localhost:8088"
+    camunda_operate_url: str = "http://localhost:8088"
+
+    @field_validator("zeebe_grpc")
+    @classmethod
+    def _validate_grpc_address(cls, v: str) -> str:
+        if not v:
+            raise ValueError("zeebe_grpc must not be empty")
+        if v.startswith(("http://", "https://")):
+            raise ValueError(
+                "zeebe_grpc must be host:port without scheme, got: " + v
+            )
+        return v
+
+    @field_validator("zeebe_rest", "camunda_operate_url")
+    @classmethod
+    def _validate_http_url(cls, v: str) -> str:
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("must start with http:// or https://, got: " + v)
+        return v
+
+    @classmethod
+    def from_env(cls) -> ZeebeConfig:
+        """Create config from environment variables with defaults."""
+        kwargs: dict[str, str] = {}
+        env_map = {
+            "ZEEBE_GRPC": "zeebe_grpc",
+            "ZEEBE_REST": "zeebe_rest",
+            "CAMUNDA_OPERATE_URL": "camunda_operate_url",
+        }
+        for env_key, field_name in env_map.items():
+            val = os.environ.get(env_key)
+            if val is not None:
+                kwargs[field_name] = val
+        return cls(**kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import contextlib
 import os
 import socket
-from typing import Generator
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 # CI cluster defaults (unauthenticated, for automated testing)
 CI_ZEEBE_GRPC = "localhost:36500"
@@ -96,10 +100,8 @@ def instance_cleanup(zeebe_grpc_address: str) -> Generator[list[int], None, None
             channel = create_insecure_channel(grpc_address=zeebe_grpc_address)
             client = SyncZeebeClient(grpc_channel=channel)
             for key in keys:
-                try:
+                with contextlib.suppress(Exception):
                     client.cancel_process_instance(key)
-                except Exception:
-                    pass  # Already completed or gone
         finally:
             loop.close()
     except ImportError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,96 @@
+"""Shared test fixtures."""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Generator
+
+import pytest
+
+# CI cluster defaults (unauthenticated, for automated testing)
+CI_ZEEBE_GRPC = "localhost:36500"
+CI_CAMUNDA_REST = "http://localhost:18088"
+
+
+def _check_tcp(host: str, port: int, timeout: float = 2.0) -> bool:
+    """Check if a TCP port is reachable."""
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _check_http(url: str, timeout: float = 2.0) -> bool:
+    """Check if an HTTP endpoint returns a non-error response."""
+    try:
+        import httpx
+
+        resp = httpx.get(f"{url}/v2/topology", timeout=timeout)
+        return resp.status_code < 500
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="session")
+def zeebe_grpc_address() -> str:
+    """Zeebe gRPC address for integration tests."""
+    return os.environ.get("ZEEBE_GRPC", CI_ZEEBE_GRPC)
+
+
+@pytest.fixture(scope="session")
+def camunda_rest_url() -> str:
+    """Camunda REST API base URL for integration tests.
+
+    In Camunda 8.8's consolidated image, the Zeebe REST API and
+    Operate share the same base URL. We use ZEEBE_REST (not
+    CAMUNDA_OPERATE_URL) because the /v2/process-instances/search
+    endpoint is part of the Zeebe REST API, not Operate's UI API.
+    The env var fallback chain: ZEEBE_REST -> CI cluster default.
+    """
+    return os.environ.get("ZEEBE_REST", CI_CAMUNDA_REST)
+
+
+@pytest.fixture(scope="session")
+def zeebe_available(zeebe_grpc_address: str, camunda_rest_url: str) -> None:
+    """Skip test if the Camunda CI cluster is not reachable.
+
+    Checks both Zeebe gRPC and the Camunda REST API.
+    """
+    host, port_str = zeebe_grpc_address.rsplit(":", 1)
+    if not _check_tcp(host, int(port_str)):
+        pytest.skip(
+            f"Zeebe gRPC not reachable at {zeebe_grpc_address}"
+        )
+    if not _check_http(camunda_rest_url):
+        pytest.skip(
+            f"Camunda REST API not reachable at {camunda_rest_url}"
+        )
+
+
+@pytest.fixture()
+def instance_cleanup(zeebe_grpc_address: str) -> Generator[list[int], None, None]:
+    """Best-effort cancel of test process instances on teardown.
+
+    Append instance keys to the yielded list during the test.
+    On teardown, attempts to cancel each. Does not fail if already
+    completed or gone.
+    """
+    keys: list[int] = []
+    yield keys
+    if not keys:
+        return
+    try:
+        from pyzeebe import SyncZeebeClient
+        from pyzeebe.channel import create_insecure_channel
+
+        channel = create_insecure_channel(grpc_address=zeebe_grpc_address)
+        client = SyncZeebeClient(grpc_channel=channel)
+        for key in keys:
+            try:
+                client.cancel_process_instance(key)
+            except Exception:
+                pass  # Already completed or gone
+    except ImportError:
+        pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,15 +82,25 @@ def instance_cleanup(zeebe_grpc_address: str) -> Generator[list[int], None, None
     if not keys:
         return
     try:
+        import asyncio
+
         from pyzeebe import SyncZeebeClient
         from pyzeebe.channel import create_insecure_channel
 
-        channel = create_insecure_channel(grpc_address=zeebe_grpc_address)
-        client = SyncZeebeClient(grpc_channel=channel)
-        for key in keys:
-            try:
-                client.cancel_process_instance(key)
-            except Exception:
-                pass  # Already completed or gone
+        # asyncio.run() in run_worker closes the default event loop.
+        # grpc.aio and SyncZeebeClient both require a running event loop,
+        # so we install a fresh one before constructing the cleanup client.
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            channel = create_insecure_channel(grpc_address=zeebe_grpc_address)
+            client = SyncZeebeClient(grpc_channel=channel)
+            for key in keys:
+                try:
+                    client.cancel_process_instance(key)
+                except Exception:
+                    pass  # Already completed or gone
+        finally:
+            loop.close()
     except ImportError:
         pass

--- a/tests/test_bpmn.py
+++ b/tests/test_bpmn.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from xml.etree.ElementTree import Element
 
 BPMN_PATH = Path(__file__).resolve().parent.parent / "processes" / "issue-lifecycle.bpmn"
 
@@ -11,6 +17,17 @@ BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
 ZEEBE_NS = "http://camunda.org/schema/zeebe/1.0"
 
 EXPECTED_PHASES = ["triage", "design", "planning", "implement", "review", "integrate"]
+
+
+@pytest.fixture(scope="module")
+def bpmn_process() -> Element:
+    """Parse the BPMN file once per module and return the process element."""
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+    return process
 
 
 def test_bpmn_file_exists() -> None:
@@ -21,14 +38,9 @@ def test_bpmn_well_formed_xml() -> None:
     ET.parse(BPMN_PATH)  # Raises ParseError if malformed
 
 
-def test_bpmn_process_id() -> None:
-    tree = ET.parse(BPMN_PATH)
-    root = tree.getroot()
-    ns = {"bpmn": BPMN_NS}
-    processes = root.findall("bpmn:process", ns)
-    assert len(processes) == 1
-    assert processes[0].get("id") == "issue-lifecycle"
-    assert processes[0].get("isExecutable") == "true"
+def test_bpmn_process_id(bpmn_process: Element) -> None:
+    assert bpmn_process.get("id") == "issue-lifecycle"
+    assert bpmn_process.get("isExecutable") == "true"
 
 
 def test_bpmn_zeebe_namespace_declared() -> None:
@@ -36,35 +48,23 @@ def test_bpmn_zeebe_namespace_declared() -> None:
     assert ZEEBE_NS in text, "Zeebe extension namespace not declared"
 
 
-def test_bpmn_six_service_tasks() -> None:
-    tree = ET.parse(BPMN_PATH)
-    root = tree.getroot()
+def test_bpmn_six_service_tasks(bpmn_process: Element) -> None:
     ns = {"bpmn": BPMN_NS}
-    process = root.find("bpmn:process", ns)
-    assert process is not None
-    tasks = process.findall("bpmn:serviceTask", ns)
+    tasks = bpmn_process.findall("bpmn:serviceTask", ns)
     assert len(tasks) == 6, f"Expected 6 service tasks, got {len(tasks)}"
 
 
-def test_bpmn_task_ids() -> None:
-    tree = ET.parse(BPMN_PATH)
-    root = tree.getroot()
+def test_bpmn_task_ids(bpmn_process: Element) -> None:
     ns = {"bpmn": BPMN_NS}
-    process = root.find("bpmn:process", ns)
-    assert process is not None
-    tasks = process.findall("bpmn:serviceTask", ns)
+    tasks = bpmn_process.findall("bpmn:serviceTask", ns)
     task_ids = [t.get("id") for t in tasks]
     expected_ids = [f"Activity_{phase}" for phase in EXPECTED_PHASES]
     assert task_ids == expected_ids
 
 
-def test_bpmn_job_types() -> None:
-    tree = ET.parse(BPMN_PATH)
-    root = tree.getroot()
+def test_bpmn_job_types(bpmn_process: Element) -> None:
     ns = {"bpmn": BPMN_NS, "zeebe": ZEEBE_NS}
-    process = root.find("bpmn:process", ns)
-    assert process is not None
-    tasks = process.findall("bpmn:serviceTask", ns)
+    tasks = bpmn_process.findall("bpmn:serviceTask", ns)
     job_types: list[str] = []
     for task in tasks:
         ext = task.find("bpmn:extensionElements", ns)
@@ -77,17 +77,13 @@ def test_bpmn_job_types() -> None:
     assert job_types == EXPECTED_PHASES
 
 
-def test_bpmn_sequence_flow_connectivity() -> None:
+def test_bpmn_sequence_flow_connectivity(bpmn_process: Element) -> None:
     """Verify start -> 6 tasks in order -> end via sequence flows."""
-    tree = ET.parse(BPMN_PATH)
-    root = tree.getroot()
     ns = {"bpmn": BPMN_NS}
-    process = root.find("bpmn:process", ns)
-    assert process is not None
 
     # Build adjacency from sequence flows
     flows: dict[str, str] = {}
-    for sf in process.findall("bpmn:sequenceFlow", ns):
+    for sf in bpmn_process.findall("bpmn:sequenceFlow", ns):
         src = sf.get("sourceRef")
         tgt = sf.get("targetRef")
         assert src is not None and tgt is not None

--- a/tests/test_bpmn.py
+++ b/tests/test_bpmn.py
@@ -1,0 +1,107 @@
+"""Tests for the BPMN process model artifact."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+BPMN_PATH = Path(__file__).resolve().parent.parent / "processes" / "issue-lifecycle.bpmn"
+
+BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+ZEEBE_NS = "http://camunda.org/schema/zeebe/1.0"
+
+EXPECTED_PHASES = ["triage", "design", "planning", "implement", "review", "integrate"]
+
+
+def test_bpmn_file_exists() -> None:
+    assert BPMN_PATH.exists(), f"BPMN file not found at {BPMN_PATH}"
+
+
+def test_bpmn_well_formed_xml() -> None:
+    ET.parse(BPMN_PATH)  # Raises ParseError if malformed
+
+
+def test_bpmn_process_id() -> None:
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    processes = root.findall("bpmn:process", ns)
+    assert len(processes) == 1
+    assert processes[0].get("id") == "issue-lifecycle"
+    assert processes[0].get("isExecutable") == "true"
+
+
+def test_bpmn_zeebe_namespace_declared() -> None:
+    text = BPMN_PATH.read_text()
+    assert ZEEBE_NS in text, "Zeebe extension namespace not declared"
+
+
+def test_bpmn_six_service_tasks() -> None:
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+    tasks = process.findall("bpmn:serviceTask", ns)
+    assert len(tasks) == 6, f"Expected 6 service tasks, got {len(tasks)}"
+
+
+def test_bpmn_task_ids() -> None:
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+    tasks = process.findall("bpmn:serviceTask", ns)
+    task_ids = [t.get("id") for t in tasks]
+    expected_ids = [f"Activity_{phase}" for phase in EXPECTED_PHASES]
+    assert task_ids == expected_ids
+
+
+def test_bpmn_job_types() -> None:
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS, "zeebe": ZEEBE_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+    tasks = process.findall("bpmn:serviceTask", ns)
+    job_types: list[str] = []
+    for task in tasks:
+        ext = task.find("bpmn:extensionElements", ns)
+        assert ext is not None, f"No extensionElements on {task.get('id')}"
+        td = ext.find("zeebe:taskDefinition", ns)
+        assert td is not None, f"No zeebe:taskDefinition on {task.get('id')}"
+        jt = td.get("type")
+        assert jt is not None
+        job_types.append(jt)
+    assert job_types == EXPECTED_PHASES
+
+
+def test_bpmn_sequence_flow_connectivity() -> None:
+    """Verify start -> 6 tasks in order -> end via sequence flows."""
+    tree = ET.parse(BPMN_PATH)
+    root = tree.getroot()
+    ns = {"bpmn": BPMN_NS}
+    process = root.find("bpmn:process", ns)
+    assert process is not None
+
+    # Build adjacency from sequence flows
+    flows: dict[str, str] = {}
+    for sf in process.findall("bpmn:sequenceFlow", ns):
+        src = sf.get("sourceRef")
+        tgt = sf.get("targetRef")
+        assert src is not None and tgt is not None
+        flows[src] = tgt
+
+    # Walk the chain: StartEvent_1 -> ... -> EndEvent_1
+    expected_chain = (
+        ["StartEvent_1"]
+        + [f"Activity_{p}" for p in EXPECTED_PHASES]
+        + ["EndEvent_1"]
+    )
+    for i in range(len(expected_chain) - 1):
+        src = expected_chain[i]
+        assert src in flows, f"No outgoing flow from {src}"
+        assert flows[src] == expected_chain[i + 1], (
+            f"Expected {src} -> {expected_chain[i + 1]}, got {src} -> {flows[src]}"
+        )

--- a/tests/test_orchestration_client.py
+++ b/tests/test_orchestration_client.py
@@ -1,0 +1,147 @@
+"""Tests for orchestration client facade."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+
+class TestConditionalImport:
+    def test_module_imports_without_pyzeebe(self) -> None:
+        """The orchestration.client module should import cleanly even
+        when pyzeebe is not installed."""
+        saved = {}
+        to_remove = [k for k in sys.modules if k.startswith("pyzeebe")]
+        for k in to_remove:
+            saved[k] = sys.modules.pop(k)
+
+        try:
+            with patch.dict(sys.modules, {"pyzeebe": None, "pyzeebe.channel": None}):
+                import importlib
+
+                import sdlc_control_plane.orchestration.client as mod
+
+                importlib.reload(mod)
+                assert hasattr(mod, "ZeebeClient")
+        finally:
+            sys.modules.update(saved)
+            import importlib
+
+            import sdlc_control_plane.orchestration.client as mod
+
+            importlib.reload(mod)
+
+    def test_constructor_raises_without_pyzeebe(self) -> None:
+        """ZeebeClient() should raise ImportError with install instructions."""
+        saved = {}
+        to_remove = [k for k in sys.modules if k.startswith("pyzeebe")]
+        for k in to_remove:
+            saved[k] = sys.modules.pop(k)
+
+        try:
+            with patch.dict(
+                sys.modules, {"pyzeebe": None, "pyzeebe.channel": None}
+            ):
+                import importlib
+
+                import sdlc_control_plane.orchestration.client as mod
+
+                importlib.reload(mod)
+                config = ZeebeConfig()
+                with pytest.raises(ImportError, match="uv sync --extra camunda"):
+                    mod.ZeebeClient(config)
+        finally:
+            sys.modules.update(saved)
+            import importlib
+
+            import sdlc_control_plane.orchestration.client as mod
+
+            importlib.reload(mod)
+
+
+def _make_client() -> Any:
+    """Build a ZeebeClient with all pyzeebe internals mocked."""
+    from sdlc_control_plane.orchestration.client import ZeebeClient
+
+    config = ZeebeConfig(zeebe_grpc="localhost:36500")
+    with patch(
+        "sdlc_control_plane.orchestration.client.create_insecure_channel"
+    ) as mock_channel, patch(
+        "sdlc_control_plane.orchestration.client._SyncZeebeClient"
+    ):
+        mock_channel.return_value = MagicMock()
+        zclient = ZeebeClient(config)
+    return zclient
+
+
+class TestZeebeClientWithMockedPyzeebe:
+    @pytest.fixture()
+    def client(self) -> Any:
+        """Create a ZeebeClient with mocked pyzeebe."""
+        return _make_client()
+
+    def test_construction_succeeds(self, client: Any) -> None:
+        assert client is not None
+
+    def test_has_deploy_process(self, client: Any) -> None:
+        assert hasattr(client, "deploy_process")
+        assert callable(client.deploy_process)
+
+    def test_has_create_instance(self, client: Any) -> None:
+        assert hasattr(client, "create_instance")
+        assert callable(client.create_instance)
+
+    def test_has_run_worker(self, client: Any) -> None:
+        assert hasattr(client, "run_worker")
+        assert callable(client.run_worker)
+
+
+class TestDeployProcess:
+    def test_deploy_delegates_to_pyzeebe(self) -> None:
+        from sdlc_control_plane.orchestration.client import DeploymentResult
+
+        client = _make_client()
+
+        mock_response = MagicMock()
+        mock_response.deployments = [
+            MagicMock(
+                bpmn_process_id="issue-lifecycle",
+                version=1,
+                process_definition_key=12345,
+            )
+        ]
+
+        client._sync_client = MagicMock()
+        client._sync_client.deploy_resource.return_value = mock_response
+
+        result = client.deploy_process(Path("test.bpmn"))
+        assert isinstance(result, DeploymentResult)
+        assert result.process_id == "issue-lifecycle"
+        assert result.version == 1
+        assert result.process_definition_key == 12345
+
+
+class TestCreateInstance:
+    def test_create_instance_delegates_to_pyzeebe(self) -> None:
+        from sdlc_control_plane.orchestration.client import InstanceResult
+
+        client = _make_client()
+
+        mock_response = MagicMock()
+        mock_response.process_instance_key = 99999
+        mock_response.process_definition_key = 12345
+
+        client._sync_client = MagicMock()
+        client._sync_client.run_process.return_value = mock_response
+
+        result = client.create_instance(
+            "issue-lifecycle", {"issue_id": "TEST-1"}
+        )
+        assert isinstance(result, InstanceResult)
+        assert result.process_instance_key == 99999

--- a/tests/test_orchestration_client.py
+++ b/tests/test_orchestration_client.py
@@ -2,67 +2,55 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 import pytest
 
 from sdlc_control_plane.orchestration.config import ZeebeConfig
 
 
+@pytest.fixture()
+def _without_pyzeebe() -> Generator[None, None, None]:
+    """Temporarily hide pyzeebe from sys.modules, then restore and reload."""
+    saved = {}
+    to_remove = [k for k in sys.modules if k.startswith("pyzeebe")]
+    for k in to_remove:
+        saved[k] = sys.modules.pop(k)
+
+    try:
+        with patch.dict(sys.modules, {"pyzeebe": None, "pyzeebe.channel": None}):
+            yield
+    finally:
+        sys.modules.update(saved)
+        import sdlc_control_plane.orchestration.client as mod
+
+        importlib.reload(mod)
+
+
 class TestConditionalImport:
-    def test_module_imports_without_pyzeebe(self) -> None:
+    def test_module_imports_without_pyzeebe(self, _without_pyzeebe: None) -> None:
         """The orchestration.client module should import cleanly even
         when pyzeebe is not installed."""
-        saved = {}
-        to_remove = [k for k in sys.modules if k.startswith("pyzeebe")]
-        for k in to_remove:
-            saved[k] = sys.modules.pop(k)
+        import sdlc_control_plane.orchestration.client as mod
 
-        try:
-            with patch.dict(sys.modules, {"pyzeebe": None, "pyzeebe.channel": None}):
-                import importlib
+        importlib.reload(mod)
+        assert hasattr(mod, "ZeebeClient")
 
-                import sdlc_control_plane.orchestration.client as mod
-
-                importlib.reload(mod)
-                assert hasattr(mod, "ZeebeClient")
-        finally:
-            sys.modules.update(saved)
-            import importlib
-
-            import sdlc_control_plane.orchestration.client as mod
-
-            importlib.reload(mod)
-
-    def test_constructor_raises_without_pyzeebe(self) -> None:
+    def test_constructor_raises_without_pyzeebe(self, _without_pyzeebe: None) -> None:
         """ZeebeClient() should raise ImportError with install instructions."""
-        saved = {}
-        to_remove = [k for k in sys.modules if k.startswith("pyzeebe")]
-        for k in to_remove:
-            saved[k] = sys.modules.pop(k)
+        import sdlc_control_plane.orchestration.client as mod
 
-        try:
-            with patch.dict(
-                sys.modules, {"pyzeebe": None, "pyzeebe.channel": None}
-            ):
-                import importlib
-
-                import sdlc_control_plane.orchestration.client as mod
-
-                importlib.reload(mod)
-                config = ZeebeConfig()
-                with pytest.raises(ImportError, match="uv sync --extra camunda"):
-                    mod.ZeebeClient(config)
-        finally:
-            sys.modules.update(saved)
-            import importlib
-
-            import sdlc_control_plane.orchestration.client as mod
-
-            importlib.reload(mod)
+        importlib.reload(mod)
+        config = ZeebeConfig()
+        with pytest.raises(ImportError, match="uv sync --extra camunda"):
+            mod.ZeebeClient(config)
 
 
 def _make_client() -> Any:

--- a/tests/test_orchestration_config.py
+++ b/tests/test_orchestration_config.py
@@ -1,0 +1,81 @@
+"""Tests for orchestration configuration."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+
+class TestZeebeConfigDefaults:
+    def test_defaults(self) -> None:
+        config = ZeebeConfig()
+        assert config.zeebe_grpc == "localhost:26500"
+        assert config.zeebe_rest == "http://localhost:8088"
+        assert config.camunda_operate_url == "http://localhost:8088"
+
+    def test_custom_values(self) -> None:
+        config = ZeebeConfig(
+            zeebe_grpc="myhost:26500",
+            zeebe_rest="http://myhost:8088",
+            camunda_operate_url="http://myhost:8088",
+        )
+        assert config.zeebe_grpc == "myhost:26500"
+        assert config.zeebe_rest == "http://myhost:8088"
+
+
+class TestZeebeConfigFromEnv:
+    def test_reads_env_vars(self) -> None:
+        env = {
+            "ZEEBE_GRPC": "remotehost:26500",
+            "ZEEBE_REST": "http://remotehost:8088",
+            "CAMUNDA_OPERATE_URL": "http://remotehost:9090",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = ZeebeConfig.from_env()
+        assert config.zeebe_grpc == "remotehost:26500"
+        assert config.zeebe_rest == "http://remotehost:8088"
+        assert config.camunda_operate_url == "http://remotehost:9090"
+
+    def test_uses_defaults_when_env_absent(self) -> None:
+        env_keys = ["ZEEBE_GRPC", "ZEEBE_REST", "CAMUNDA_OPERATE_URL"]
+        cleaned = {k: v for k, v in os.environ.items() if k not in env_keys}
+        with patch.dict(os.environ, cleaned, clear=True):
+            config = ZeebeConfig.from_env()
+        assert config.zeebe_grpc == "localhost:26500"
+
+    def test_partial_env(self) -> None:
+        with patch.dict(os.environ, {"ZEEBE_GRPC": "custom:9999"}, clear=False):
+            config = ZeebeConfig.from_env()
+        assert config.zeebe_grpc == "custom:9999"
+        assert config.zeebe_rest == "http://localhost:8088"
+
+
+class TestZeebeConfigValidation:
+    def test_zeebe_rest_requires_http_scheme(self) -> None:
+        with pytest.raises(ValidationError, match="zeebe_rest"):
+            ZeebeConfig(zeebe_rest="localhost:8088")
+
+    def test_camunda_operate_url_requires_http_scheme(self) -> None:
+        with pytest.raises(ValidationError, match="camunda_operate_url"):
+            ZeebeConfig(camunda_operate_url="localhost:8088")
+
+    def test_zeebe_rest_accepts_https(self) -> None:
+        config = ZeebeConfig(zeebe_rest="https://secure:8088")
+        assert config.zeebe_rest == "https://secure:8088"
+
+    def test_zeebe_grpc_rejects_http_scheme(self) -> None:
+        with pytest.raises(ValidationError, match="zeebe_grpc"):
+            ZeebeConfig(zeebe_grpc="http://localhost:26500")
+
+    def test_zeebe_grpc_accepts_host_port(self) -> None:
+        config = ZeebeConfig(zeebe_grpc="myhost:26500")
+        assert config.zeebe_grpc == "myhost:26500"
+
+    def test_zeebe_grpc_rejects_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            ZeebeConfig(zeebe_grpc="")

--- a/tests/test_workflow_integration.py
+++ b/tests/test_workflow_integration.py
@@ -1,0 +1,114 @@
+"""Integration test: issue-lifecycle happy path against live Camunda cluster.
+
+Requires the Camunda CI cluster to be running (docker-compose-ci.yaml).
+Skipped automatically if the cluster is not reachable.
+
+Tests the full public facade: deploy_process, create_instance, run_worker.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from sdlc_control_plane.orchestration.client import ZeebeClient
+from sdlc_control_plane.orchestration.config import ZeebeConfig
+
+BPMN_PATH = Path(__file__).resolve().parent.parent / "processes" / "issue-lifecycle.bpmn"
+
+EXPECTED_PHASES = ["triage", "design", "planning", "implement", "review", "integrate"]
+
+
+@pytest.fixture()
+def zeebe_client(
+    zeebe_available: None, zeebe_grpc_address: str
+) -> ZeebeClient:
+    """Create a ZeebeClient connected to the CI cluster."""
+    config = ZeebeConfig(zeebe_grpc=zeebe_grpc_address)
+    return ZeebeClient(config)
+
+
+@pytest.fixture()
+def _deploy_process(zeebe_client: ZeebeClient) -> None:
+    """Deploy the issue-lifecycle BPMN to Zeebe."""
+    zeebe_client.deploy_process(BPMN_PATH)
+
+
+def _poll_instance_completed(
+    rest_url: str,
+    instance_key: int,
+    timeout: float = 10.0,
+    interval: float = 1.0,
+) -> str:
+    """Poll Camunda REST API until instance reaches a terminal state.
+
+    Uses ``zeebe_rest`` (the Zeebe REST API), not Operate. In the
+    consolidated Camunda 8.8 image both are the same endpoint, but
+    semantically this is querying the Zeebe-backed process instance
+    search, not the Operate UI API.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        resp = httpx.post(
+            f"{rest_url}/v2/process-instances/search",
+            json={
+                # Camunda REST API requires processInstanceKey as a string.
+                "filter": {"processInstanceKey": str(instance_key)},
+            },
+        )
+        if resp.status_code == 200:
+            data = resp.json()
+            items = data.get("items", [])
+            if items:
+                state = items[0].get("state", "")
+                if state in ("COMPLETED", "CANCELED", "TERMINATED"):
+                    return state
+        time.sleep(interval)
+    raise TimeoutError(
+        f"Instance {instance_key} did not reach terminal state within {timeout}s"
+    )
+
+
+@pytest.mark.integration
+class TestIssueLifecycleHappyPath:
+    def test_workflow_completes_all_phases(
+        self,
+        zeebe_client: ZeebeClient,
+        camunda_rest_url: str,
+        instance_cleanup: list[int],
+        _deploy_process: None,
+    ) -> None:
+        """Deploy, start, drive all 6 phases via facade, verify completion.
+
+        Uses ZeebeClient.run_worker() for each phase sequentially.
+        The process is sequential, so each phase's job only becomes
+        available after the previous one completes.
+        """
+        # Start instance via facade
+        result = zeebe_client.create_instance(
+            "issue-lifecycle",
+            {"issue_id": "TEST-1", "issue_type": "Implementation"},
+        )
+        instance_key = result.process_instance_key
+        assert instance_key > 0
+        instance_cleanup.append(instance_key)
+
+        # Drive all 6 phases sequentially through the facade.
+        completed: list[str] = []
+        for phase in EXPECTED_PHASES:
+            result_types = zeebe_client.run_worker(
+                job_type=phase, timeout=10.0, max_jobs=1
+            )
+            completed.extend(result_types)
+
+        # Assert ordering
+        assert completed == EXPECTED_PHASES, (
+            f"Expected {EXPECTED_PHASES}, got {completed}"
+        )
+
+        # Assert completed state via Camunda REST API.
+        state = _poll_instance_completed(camunda_rest_url, instance_key)
+        assert state == "COMPLETED", f"Expected COMPLETED, got {state}"

--- a/uv.lock
+++ b/uv.lock
@@ -392,6 +392,34 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
 name = "hypothesis"
 version = "6.151.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1075,6 +1103,7 @@ camunda = [
     { name = "pyzeebe" },
 ]
 dev = [
+    { name = "httpx" },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1086,6 +1115,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.110" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.90" },
     { name = "jsonschema", specifier = ">=4.20" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },


### PR DESCRIPTION
## Summary

- Hand-authored BPMN 2.0 process model (`processes/issue-lifecycle.bpmn`) with 6 sequential service tasks: triage → design → planning → implement → review → integrate
- Thin pyzeebe-based `ZeebeClient` facade (`orchestration/client.py`) with lazy conditional imports, `SyncZeebeClient` for deploy/start, and `asyncio.run()` wrapping `ZeebeWorker` for job completion
- `ZeebeConfig` Pydantic model with `from_env()` classmethod and host:port / HTTP URL validation
- Integration test proving the full 6-phase happy path completes against a live Camunda 8.8 CI cluster
- 8 BPMN artifact unit tests (XML structure, Zeebe extensions, sequence flow connectivity)
- Unit tests for config validation, client facade (mocked pyzeebe), and conditional import behavior

## Test Plan

- [x] `make check` passes (lint + typecheck + 281 unit tests)
- [x] `make test-integration` passes against CI cluster (1 integration test, 4.7s)
- [x] Process definition visible in Camunda via REST API search
- [x] `/simplify` review applied — deprecated API fix, resource leak fix, DRY improvements

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>